### PR TITLE
Fix BaseURL when hosted behind a TLS reverse proxy

### DIFF
--- a/app/pkg/web/context.go
+++ b/app/pkg/web/context.go
@@ -266,7 +266,7 @@ func (ctx *Context) ActiveTransaction() *dbx.Trx {
 //BaseURL returns base URL as string
 func (ctx *Context) BaseURL() string {
 	protocol := "http"
-	if ctx.Request.TLS != nil {
+	if ctx.Request.TLS != nil || ctx.Request.Header.Get("X-Forwarded-Proto") == "https" {
 		protocol = "https"
 	}
 	return protocol + "://" + ctx.Request.Host


### PR DESCRIPTION
It fixes #253 by adding a check for the standard `X-Forwarded-Proto` header.