### PR TITLE
refactor: add/remove supporters

### DIFF
--- a/app/pkg/dbx/dbx.go
+++ b/app/pkg/dbx/dbx.go
@@ -107,7 +107,7 @@ type Trx struct {
 var formatter = strings.NewReplacer("\t", "", "\n", " ")
 
 // Execute given SQL command
-func (trx Trx) Execute(command string, args ...interface{}) error {
+func (trx Trx) Execute(command string, args ...interface{}) (int64, error) {
 	if trx.logger.IsEnabled(log.DEBUG) {
 		command = formatter.Replace(command)
 		start := time.Now()
@@ -116,8 +116,11 @@ func (trx Trx) Execute(command string, args ...interface{}) error {
 		}()
 	}
 
-	_, err := trx.tx.Exec(command, args...)
-	return err
+	result, err := trx.tx.Exec(command, args...)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 // Scalar returns first row and first column

--- a/app/storage/postgres/notifications.go
+++ b/app/storage/postgres/notifications.go
@@ -72,10 +72,11 @@ func (s *NotificationStorage) MarkAsRead(id int) error {
 	if s.user == nil {
 		return nil
 	}
-	return s.trx.Execute(`
+	_, err := s.trx.Execute(`
 		UPDATE notifications SET read = true, updated_on = $1
 		WHERE id = $2 AND tenant_id = $3 AND user_id = $4 AND read = false
 	`, time.Now(), id, s.tenant.ID, s.user.ID)
+	return err
 }
 
 // MarkAllAsRead of current user
@@ -83,10 +84,11 @@ func (s *NotificationStorage) MarkAllAsRead() error {
 	if s.user == nil {
 		return nil
 	}
-	return s.trx.Execute(`
+	_, err := s.trx.Execute(`
 		UPDATE notifications SET read = true, updated_on = $1
 		WHERE tenant_id = $2 AND user_id = $3 AND read = false
 	`, time.Now(), s.tenant.ID, s.user.ID)
+	return err
 }
 
 // GetActiveNotifications returns all unread notifications and last 30 days of read notifications

--- a/app/storage/postgres/tag.go
+++ b/app/storage/postgres/tag.go
@@ -83,7 +83,7 @@ func (s *TagStorage) GetBySlug(slug string) (*models.Tag, error) {
 func (s *TagStorage) Update(tagID int, name, color string, isPublic bool) (*models.Tag, error) {
 	tagSlug := slug.Make(name)
 
-	err := s.trx.Execute(`UPDATE tags SET name = $1, slug = $2, color = $3, is_public = $4
+	_, err := s.trx.Execute(`UPDATE tags SET name = $1, slug = $2, color = $3, is_public = $4
 												WHERE id = $5 AND tenant_id = $6`, name, tagSlug, color, isPublic, tagID, s.tenant.ID)
 	if err != nil {
 		return nil, err
@@ -94,11 +94,12 @@ func (s *TagStorage) Update(tagID int, name, color string, isPublic bool) (*mode
 
 // Delete a tag by its id
 func (s *TagStorage) Delete(tagID int) error {
-	err := s.trx.Execute(`DELETE FROM idea_tags WHERE tag_id = $1 AND tenant_id = $2`, tagID, s.tenant.ID)
+	_, err := s.trx.Execute(`DELETE FROM idea_tags WHERE tag_id = $1 AND tenant_id = $2`, tagID, s.tenant.ID)
 	if err != nil {
 		return err
 	}
-	return s.trx.Execute(`DELETE FROM tags WHERE id = $1 AND tenant_id = $2`, tagID, s.tenant.ID)
+	_, err = s.trx.Execute(`DELETE FROM tags WHERE id = $1 AND tenant_id = $2`, tagID, s.tenant.ID)
+	return err
 }
 
 // AssignTag adds a tag to an idea
@@ -112,18 +113,20 @@ func (s *TagStorage) AssignTag(tagID, ideaID, userID int) error {
 		return nil
 	}
 
-	return s.trx.Execute(
+	_, err = s.trx.Execute(
 		`INSERT INTO idea_tags (tag_id, idea_id, created_on, created_by_id, tenant_id) VALUES ($1, $2, $3, $4, $5)`,
 		tagID, ideaID, time.Now(), userID, s.tenant.ID,
 	)
+	return err
 }
 
 // UnassignTag removes a tag from an idea
 func (s *TagStorage) UnassignTag(tagID, ideaID int) error {
-	return s.trx.Execute(
+	_, err := s.trx.Execute(
 		`DELETE FROM idea_tags WHERE tag_id = $1 AND idea_id = $2 AND tenant_id = $3`,
 		tagID, ideaID, s.tenant.ID,
 	)
+	return err
 }
 
 // GetAssigned returns all tags assigned to given idea

--- a/app/storage/postgres/tenant.go
+++ b/app/storage/postgres/tenant.go
@@ -132,7 +132,8 @@ func (s *TenantStorage) GetByDomain(domain string) (*models.Tenant, error) {
 // UpdateSettings of given tenant
 func (s *TenantStorage) UpdateSettings(settings *models.UpdateTenantSettings) error {
 	query := "UPDATE tenants SET name = $1, invitation = $2, welcome_message = $3, cname = $4 WHERE id = $5"
-	return s.trx.Execute(query, settings.Title, settings.Invitation, settings.WelcomeMessage, settings.CNAME, s.current.ID)
+	_, err := s.trx.Execute(query, settings.Title, settings.Invitation, settings.WelcomeMessage, settings.CNAME, s.current.ID)
+	return err
 }
 
 // IsSubdomainAvailable returns true if subdomain is available to use
@@ -150,7 +151,8 @@ func (s *TenantStorage) IsCNAMEAvailable(cname string) (bool, error) {
 // Activate given tenant
 func (s *TenantStorage) Activate(id int) error {
 	query := "UPDATE tenants SET status = $1 WHERE id = $2"
-	return s.trx.Execute(query, models.TenantActive, id)
+	_, err := s.trx.Execute(query, models.TenantActive, id)
+	return err
 }
 
 // SaveVerificationKey used by email verification process
@@ -160,7 +162,8 @@ func (s *TenantStorage) SaveVerificationKey(key string, duration time.Duration, 
 		userID = request.GetUser().ID
 	}
 	query := "INSERT INTO email_verifications (tenant_id, email, created_on, expires_on, key, name, kind, user_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
-	return s.trx.Execute(query, s.current.ID, request.GetEmail(), time.Now(), time.Now().Add(duration), key, request.GetName(), request.GetKind(), userID)
+	_, err := s.trx.Execute(query, s.current.ID, request.GetEmail(), time.Now(), time.Now().Add(duration), key, request.GetName(), request.GetKind(), userID)
+	return err
 }
 
 // FindVerificationByKey based on current tenant
@@ -179,7 +182,8 @@ func (s *TenantStorage) FindVerificationByKey(kind models.EmailVerificationKind,
 // SetKeyAsVerified so that it cannot be used anymore
 func (s *TenantStorage) SetKeyAsVerified(key string) error {
 	query := "UPDATE email_verifications SET verified_on = $1 WHERE tenant_id = $2 AND key = $3"
-	return s.trx.Execute(query, time.Now(), s.current.ID, key)
+	_, err := s.trx.Execute(query, time.Now(), s.current.ID, key)
+	return err
 }
 
 func extractSubdomain(hostname string) string {

--- a/app/storage/postgres/user.go
+++ b/app/storage/postgres/user.go
@@ -115,7 +115,7 @@ func (s *UserStorage) Register(user *models.User) error {
 	}
 
 	for _, provider := range user.Providers {
-		if err := s.trx.Execute("INSERT INTO user_providers (tenant_id, user_id, provider, provider_uid, created_on) VALUES ($1, $2, $3, $4, $5)", s.tenant.ID, user.ID, provider.Name, provider.UID, now); err != nil {
+		if _, err := s.trx.Execute("INSERT INTO user_providers (tenant_id, user_id, provider, provider_uid, created_on) VALUES ($1, $2, $3, $4, $5)", s.tenant.ID, user.ID, provider.Name, provider.UID, now); err != nil {
 			return err
 		}
 	}
@@ -126,13 +126,15 @@ func (s *UserStorage) Register(user *models.User) error {
 // RegisterProvider adds given provider to userID
 func (s *UserStorage) RegisterProvider(userID int, provider *models.UserProvider) error {
 	cmd := "INSERT INTO user_providers (tenant_id, user_id, provider, provider_uid, created_on) VALUES ($1, $2, $3, $4, $5)"
-	return s.trx.Execute(cmd, s.tenant.ID, userID, provider.Name, provider.UID, time.Now())
+	_, err := s.trx.Execute(cmd, s.tenant.ID, userID, provider.Name, provider.UID, time.Now())
+	return err
 }
 
 // Update user profile
 func (s *UserStorage) Update(settings *models.UpdateUserSettings) error {
 	cmd := "UPDATE users SET name = $2 WHERE id = $1 AND tenant_id = $3"
-	return s.trx.Execute(cmd, s.user.ID, settings.Name, s.tenant.ID)
+	_, err := s.trx.Execute(cmd, s.user.ID, settings.Name, s.tenant.ID)
+	return err
 }
 
 // UpdateSettings of given user
@@ -144,7 +146,7 @@ func (s *UserStorage) UpdateSettings(settings map[string]string) error {
 		`
 
 		for key, value := range settings {
-			err := s.trx.Execute(query, s.tenant.ID, s.user.ID, key, value)
+			_, err := s.trx.Execute(query, s.tenant.ID, s.user.ID, key, value)
 			if err != nil {
 				return err
 			}
@@ -185,13 +187,15 @@ func (s *UserStorage) GetUserSettings() (map[string]string, error) {
 // ChangeRole of given user
 func (s *UserStorage) ChangeRole(userID int, role models.Role) error {
 	cmd := "UPDATE users SET role = $3 WHERE id = $1 AND tenant_id = $2"
-	return s.trx.Execute(cmd, userID, s.tenant.ID, role)
+	_, err := s.trx.Execute(cmd, userID, s.tenant.ID, role)
+	return err
 }
 
 // ChangeEmail of given user
 func (s *UserStorage) ChangeEmail(userID int, email string) error {
 	cmd := "UPDATE users SET email = $3 WHERE id = $1 AND tenant_id = $2"
-	return s.trx.Execute(cmd, userID, s.tenant.ID, email)
+	_, err := s.trx.Execute(cmd, userID, s.tenant.ID, email)
+	return err
 }
 
 // GetByID returns a user based on given id


### PR DESCRIPTION
**Issue:** closes #277

- `trx.Execute` now returns number of affected rows.
- Add/Remove support rely on number of affected rows instead of additional SELECT query.