### PR TITLE
render 410 page when link has been used/expired

### DIFF
--- a/app/handlers/common.go
+++ b/app/handlers/common.go
@@ -40,6 +40,7 @@ func Page() web.HandlerFunc {
 func validateKey(kind models.EmailVerificationKind, c web.Context) (*models.EmailVerification, error) {
 	key := c.QueryParam("k")
 
+	//If key has been used, return NotFound
 	result, err := c.Services().Tenants.FindVerificationByKey(kind, key)
 	if err != nil {
 		if errors.Cause(err) == app.ErrNotFound {
@@ -53,7 +54,7 @@ func validateKey(kind models.EmailVerificationKind, c web.Context) (*models.Emai
 		return nil, c.Gone()
 	}
 
-	//If key expired, render the expired page
+	//If key expired, return Gone
 	if time.Now().After(result.ExpiresOn) {
 		err = c.Services().Tenants.SetKeyAsVerified(key)
 		if err != nil {

--- a/app/handlers/common.go
+++ b/app/handlers/common.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"net/http"
 	"runtime"
 	"time"
 
@@ -44,23 +43,23 @@ func validateKey(kind models.EmailVerificationKind, c web.Context) (*models.Emai
 	result, err := c.Services().Tenants.FindVerificationByKey(kind, key)
 	if err != nil {
 		if errors.Cause(err) == app.ErrNotFound {
-			return nil, c.Redirect(http.StatusTemporaryRedirect, c.BaseURL())
+			return nil, c.NotFound()
 		}
 		return nil, c.Failure(err)
 	}
 
-	//If key has been used, just go back to home page
+	//If key has been used, return Gone
 	if result.VerifiedOn != nil {
-		return nil, c.Redirect(http.StatusTemporaryRedirect, c.BaseURL())
+		return nil, c.Gone()
 	}
 
-	//If key expired, go back to home page
+	//If key expired, render the expired page
 	if time.Now().After(result.ExpiresOn) {
 		err = c.Services().Tenants.SetKeyAsVerified(key)
 		if err != nil {
 			return nil, c.Failure(err)
 		}
-		return nil, c.Redirect(http.StatusTemporaryRedirect, c.BaseURL())
+		return nil, c.Gone()
 	}
 
 	return result, nil

--- a/app/handlers/signin_test.go
+++ b/app/handlers/signin_test.go
@@ -201,13 +201,12 @@ func TestVerifySignInKeyHandler_UnknownKey(t *testing.T) {
 	RegisterTestingT(t)
 
 	server, _ := mock.NewServer()
-	code, response := server.
+	code, _ := server.
 		OnTenant(mock.DemoTenant).
 		WithURL("http://demo.test.fider.io/signin/verify?k=unknown").
 		Execute(handlers.VerifySignInKey(models.EmailVerificationKindSignIn))
 
-	Expect(code).To(Equal(http.StatusTemporaryRedirect))
-	Expect(response.Header().Get("Location")).To(Equal("http://demo.test.fider.io"))
+	Expect(code).To(Equal(http.StatusNotFound))
 }
 
 func TestVerifySignInKeyHandler_UsedKey(t *testing.T) {
@@ -219,13 +218,12 @@ func TestVerifySignInKeyHandler_UsedKey(t *testing.T) {
 	services.Tenants.SaveVerificationKey("1234567890", 15*time.Minute, e)
 	services.Tenants.SetKeyAsVerified("1234567890")
 
-	code, response := server.
+	code, _ := server.
 		OnTenant(mock.DemoTenant).
 		WithURL("http://demo.test.fider.io/signin/verify?k=1234567890").
 		Execute(handlers.VerifySignInKey(models.EmailVerificationKindSignIn))
 
-	Expect(code).To(Equal(http.StatusTemporaryRedirect))
-	Expect(response.Header().Get("Location")).To(Equal("http://demo.test.fider.io"))
+	Expect(code).To(Equal(http.StatusGone))
 }
 
 func TestVerifySignInKeyHandler_ExpiredKey(t *testing.T) {
@@ -238,13 +236,12 @@ func TestVerifySignInKeyHandler_ExpiredKey(t *testing.T) {
 	request, _ := services.Tenants.FindVerificationByKey(models.EmailVerificationKindSignIn, "1234567890")
 	request.ExpiresOn = request.CreatedOn.Add(-6 * time.Minute) //reduce 1 minute
 
-	code, response := server.
+	code, _ := server.
 		OnTenant(mock.DemoTenant).
 		WithURL("http://demo.test.fider.io/signin/verify?k=1234567890").
 		Execute(handlers.VerifySignInKey(models.EmailVerificationKindSignIn))
 
-	Expect(code).To(Equal(http.StatusTemporaryRedirect))
-	Expect(response.Header().Get("Location")).To(Equal("http://demo.test.fider.io"))
+	Expect(code).To(Equal(http.StatusGone))
 }
 
 func TestVerifySignInKeyHandler_CorrectKey_ExistingUser(t *testing.T) {

--- a/app/pkg/web/context.go
+++ b/app/pkg/web/context.go
@@ -177,6 +177,11 @@ func (ctx *Context) NotFound() error {
 	return ctx.Render(http.StatusNotFound, "404.html", Map{})
 }
 
+//Gone returns a 410 page
+func (ctx *Context) Gone() error {
+	return ctx.Render(http.StatusGone, "410.html", Map{})
+}
+
 //Failure returns a 500 page
 func (ctx *Context) Failure(err error) error {
 	err = errors.StackN(err, 1)

--- a/app/pkg/web/renderer.go
+++ b/app/pkg/web/renderer.go
@@ -34,6 +34,7 @@ func NewRenderer(settings *models.SystemSettings, logger log.Logger) *Renderer {
 	r.add("index.html")
 	r.add("403.html")
 	r.add("404.html")
+	r.add("410.html")
 	r.add("500.html")
 
 	r.jsBundle = r.getBundle("/dist/js")

--- a/views/410.html
+++ b/views/410.html
@@ -1,0 +1,19 @@
+{{define "title"}}
+  Expired &middot; Fider
+{{end}}
+        
+{{define "javascript"}}{{end}}
+
+{{define "content"}}
+  <div class="ui middle aligned center aligned grid failure-page">
+    <div class="column">
+      <img src="https://getfider.com/images/logo-100x100.png"/>
+      <h1>EXPIRED</h1>
+      <p>The link you clicked has expired.</p>
+
+      {{ if .tenant }}
+        <span>Take me back to <a href="{{ .baseURL }}">{{ .tenant.Subdomain }}.fider.io</a> home page.</span>
+      {{ end }}
+    </div>
+  </div>
+{{end}}


### PR DESCRIPTION
**Issue:**  closes #170

Introduces the `410 GONE` page used for verification keys that have been user or expired