### PR TITLE
fix for gravatar issue on IE11

### DIFF
--- a/app/handlers/avatar.go
+++ b/app/handlers/avatar.go
@@ -34,7 +34,7 @@ func Avatar() web.HandlerFunc {
 						if resp.StatusCode == http.StatusOK {
 							bytes, err := ioutil.ReadAll(resp.Body)
 							if err == nil {
-								return c.Blob(http.StatusOK, "image/png", bytes)
+								return c.Blob(http.StatusOK, http.DetectContentType(bytes), bytes)
 							}
 						}
 					}


### PR DESCRIPTION
**Issue:**  closes #338

Detect Gravatar content type instead of forcing it to `image/png`, IE doesn't like it.