### PR TITLE
add tags to mailgun deliveries

### DIFF
--- a/app/handlers/invite.go
+++ b/app/handlers/invite.go
@@ -25,7 +25,7 @@ func SendSampleInvite() web.HandlerFunc {
 				"subject": input.Model.Subject,
 				"message": markdown.Parse(input.Model.Message),
 			})
-			err := c.Services().Emailer.Send("invite_email", email.Params{}, c.Tenant().Name, to)
+			err := c.Services().Emailer.Send(c.Tenant(), "invite_email", email.Params{}, c.Tenant().Name, to)
 			if err != nil {
 				return c.Failure(err)
 			}

--- a/app/pkg/email/email.go
+++ b/app/pkg/email/email.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/getfider/fider/app/models"
 	"github.com/getfider/fider/app/pkg/env"
 )
 
@@ -91,8 +92,8 @@ func CanSendTo(address string) bool {
 
 // Sender is used to send emails
 type Sender interface {
-	Send(templateName string, params Params, from string, to Recipient) error
-	BatchSend(templateName string, params Params, from string, to []Recipient) error
+	Send(tenant *models.Tenant, templateName string, params Params, from string, to Recipient) error
+	BatchSend(tenant *models.Tenant, templateName string, params Params, from string, to []Recipient) error
 }
 
 // NoopSender does not send emails
@@ -105,12 +106,12 @@ func NewNoopSender() *NoopSender {
 }
 
 // Send an email
-func (s *NoopSender) Send(templateName string, params Params, from string, to Recipient) error {
+func (s *NoopSender) Send(tenant *models.Tenant, templateName string, params Params, from string, to Recipient) error {
 	return nil
 
 }
 
 // BatchSend an email to multiple recipients
-func (s *NoopSender) BatchSend(templateName string, params Params, from string, to []Recipient) error {
+func (s *NoopSender) BatchSend(tenant *models.Tenant, templateName string, params Params, from string, to []Recipient) error {
 	return nil
 }

--- a/app/pkg/email/smtp/smtp.go
+++ b/app/pkg/email/smtp/smtp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	gosmtp "net/smtp"
 
+	"github.com/getfider/fider/app/models"
 	"github.com/getfider/fider/app/pkg/email"
 	"github.com/getfider/fider/app/pkg/errors"
 	"github.com/getfider/fider/app/pkg/log"
@@ -24,7 +25,7 @@ func NewSender(logger log.Logger, host, port, username, password string) *Sender
 }
 
 //Send an email
-func (s *Sender) Send(templateName string, params email.Params, from string, to email.Recipient) error {
+func (s *Sender) Send(tenant *models.Tenant, templateName string, params email.Params, from string, to email.Recipient) error {
 	if !email.CanSendTo(to.Address) {
 		s.logger.Warnf("Skipping email to %s <%s> due to whitelist.", to.Name, to.Address)
 		return nil
@@ -57,9 +58,9 @@ func (s *Sender) Send(templateName string, params email.Params, from string, to 
 }
 
 // BatchSend an email to multiple recipients
-func (s *Sender) BatchSend(templateName string, params email.Params, from string, to []email.Recipient) error {
+func (s *Sender) BatchSend(tenant *models.Tenant, templateName string, params email.Params, from string, to []email.Recipient) error {
 	for _, r := range to {
-		if err := s.Send(templateName, params, from, r); err != nil {
+		if err := s.Send(tenant, templateName, params, from, r); err != nil {
 			return errors.Wrap(err, "failed to batch send email to %d recipients", len(to))
 		}
 	}

--- a/app/tasks/tasks.go
+++ b/app/tasks/tasks.go
@@ -31,7 +31,7 @@ func SendSignUpEmail(model *models.CreateTenant, baseURL string) worker.Task {
 		to := email.NewRecipient(model.Name, model.Email, email.Params{
 			"link": link(baseURL, "/signup/verify?k=%s", model.VerificationKey),
 		})
-		return c.Services().Emailer.Send("signup_email", email.Params{}, "Fider", to)
+		return c.Services().Emailer.Send(c.Tenant(), "signup_email", email.Params{}, "Fider", to)
 	})
 }
 
@@ -42,7 +42,7 @@ func SendSignInEmail(model *models.SignInByEmail) worker.Task {
 			"tenantName": c.Tenant().Name,
 			"link":       link(c.BaseURL(), "/signin/verify?k=%s", model.VerificationKey),
 		})
-		return c.Services().Emailer.Send("signin_email", email.Params{}, c.Tenant().Name, to)
+		return c.Services().Emailer.Send(c.Tenant(), "signin_email", email.Params{}, c.Tenant().Name, to)
 	})
 }
 
@@ -60,7 +60,7 @@ func SendChangeEmailConfirmation(model *models.ChangeUserEmail) worker.Task {
 			"newEmail": model.Email,
 			"link":     link(c.BaseURL(), "/change-email/verify?k=%s", model.VerificationKey),
 		})
-		return c.Services().Emailer.Send("change_emailaddress_email", email.Params{}, c.Tenant().Name, to)
+		return c.Services().Emailer.Send(c.Tenant(), "change_emailaddress_email", email.Params{}, c.Tenant().Name, to)
 	})
 }
 
@@ -101,7 +101,7 @@ func NotifyAboutNewIdea(idea *models.Idea) worker.Task {
 			"change":  linkWithText("change your notification settings", c.BaseURL(), "/settings"),
 		}
 
-		return c.Services().Emailer.BatchSend("new_idea", params, c.User().Name, to)
+		return c.Services().Emailer.BatchSend(c.Tenant(), "new_idea", params, c.User().Name, to)
 	})
 }
 
@@ -143,7 +143,7 @@ func NotifyAboutNewComment(idea *models.Idea, comment *models.NewComment) worker
 			"change":      linkWithText("change your notification settings", c.BaseURL(), "/settings"),
 		}
 
-		return c.Services().Emailer.BatchSend("new_comment", params, c.User().Name, to)
+		return c.Services().Emailer.BatchSend(c.Tenant(), "new_comment", params, c.User().Name, to)
 	})
 }
 
@@ -201,7 +201,7 @@ func NotifyAboutStatusChange(idea *models.Idea, response *models.SetResponse) wo
 			"change":      linkWithText("change your notification settings", c.BaseURL(), "/settings"),
 		}
 
-		return c.Services().Emailer.BatchSend("change_status", params, c.User().Name, to)
+		return c.Services().Emailer.BatchSend(c.Tenant(), "change_status", params, c.User().Name, to)
 	})
 }
 
@@ -221,7 +221,7 @@ func SendInvites(subject, message string, invitations []*models.UserInvitation) 
 				"message": markdown.Parse(toMessage),
 			})
 		}
-		return c.Services().Emailer.BatchSend("invite_email", email.Params{
+		return c.Services().Emailer.BatchSend(c.Tenant(), "invite_email", email.Params{
 			"subject": subject,
 		}, c.User().Name, to)
 	})


### PR DESCRIPTION
**Issue:**  closes #336

Add two tags to maligun deliveries:

```
Add `o:tag="tenant:<subdomain>"` (when running on Multi-tenant mode)
Add `o:tag="event:<event_name>"`
```