### PR TITLE
fix: only add canonical link if needed

### DIFF
--- a/app/middlewares/domain.go
+++ b/app/middlewares/domain.go
@@ -55,9 +55,13 @@ func MultiTenant() web.MiddlewareFunc {
 			tenant, err := c.Services().Tenants.GetByDomain(hostname)
 			if err == nil {
 				c.SetTenant(tenant)
+
 				if tenant.CNAME != "" && !c.IsAjax() {
-					link := c.TenantBaseURL(tenant) + c.Request.URL.RequestURI()
-					c.Response.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"canonical\"", link))
+					baseURL := c.TenantBaseURL(tenant)
+					if baseURL != c.BaseURL() {
+						link := baseURL + c.Request.URL.RequestURI()
+						c.Response.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"canonical\"", link))
+					}
 				}
 				return next(c)
 			}

--- a/app/middlewares/domain_test.go
+++ b/app/middlewares/domain_test.go
@@ -96,6 +96,11 @@ func TestMultiTenant_CanonicalHeader(t *testing.T) {
 			true,
 		},
 		{
+			"http://ideas.theavengers.com/",
+			"",
+			false,
+		},
+		{
 			"http://avengers.test.fider.io/ideas",
 			"<http://ideas.theavengers.com/ideas>; rel=\"canonical\"",
 			false,

--- a/app/storage/inmemory/tenant.go
+++ b/app/storage/inmemory/tenant.go
@@ -48,7 +48,7 @@ func (s *TenantStorage) First() (*models.Tenant, error) {
 // GetByDomain returns a tenant based on its domain
 func (s *TenantStorage) GetByDomain(domain string) (*models.Tenant, error) {
 	for _, tenant := range s.tenants {
-		if tenant.Subdomain == extractSubdomain(domain) {
+		if tenant.Subdomain == extractSubdomain(domain) || tenant.CNAME == domain {
 			return tenant, nil
 		}
 	}


### PR DESCRIPTION
**Issue:**  related to #274

This will only add Canonical Link if the request is not already on the correct domain