### PR TITLE
Fix typos in comments, variables and function names

### DIFF
--- a/app/handlers/apiv1/tag.go
+++ b/app/handlers/apiv1/tag.go
@@ -79,7 +79,7 @@ func CreateEditTag() web.HandlerFunc {
 	}
 }
 
-// DeleteTag deletes anexisting tag
+// DeleteTag deletes an existing tag
 func DeleteTag() web.HandlerFunc {
 	return func(c web.Context) error {
 		input := new(actions.DeleteTag)

--- a/app/models/feedback.go
+++ b/app/models/feedback.go
@@ -199,11 +199,11 @@ var (
 
 //NotificationEvent represents all possible notification events
 type NotificationEvent struct {
-	UserSettingsKeyName          string
-	DefaultSettingValue          string
-	RequiresSubscripionUserRoles []Role
-	DefaultEnabledUserRoles      []Role
-	Validate                     func(string) bool
+	UserSettingsKeyName           string
+	DefaultSettingValue           string
+	RequiresSubscriptionUserRoles []Role
+	DefaultEnabledUserRoles       []Role
+	Validate                      func(string) bool
 }
 
 func notificationEventValidation(v string) bool {
@@ -213,9 +213,9 @@ func notificationEventValidation(v string) bool {
 var (
 	//NotificationEventNewPost is triggered when a new post is posted
 	NotificationEventNewPost = NotificationEvent{
-		UserSettingsKeyName:          "event_notification_new_post",
-		DefaultSettingValue:          strconv.Itoa(int(NotificationChannelWeb | NotificationChannelEmail)),
-		RequiresSubscripionUserRoles: []Role{},
+		UserSettingsKeyName:           "event_notification_new_post",
+		DefaultSettingValue:           strconv.Itoa(int(NotificationChannelWeb | NotificationChannelEmail)),
+		RequiresSubscriptionUserRoles: []Role{},
 		DefaultEnabledUserRoles: []Role{
 			RoleAdministrator,
 			RoleCollaborator,
@@ -226,7 +226,7 @@ var (
 	NotificationEventNewComment = NotificationEvent{
 		UserSettingsKeyName: "event_notification_new_comment",
 		DefaultSettingValue: strconv.Itoa(int(NotificationChannelWeb | NotificationChannelEmail)),
-		RequiresSubscripionUserRoles: []Role{
+		RequiresSubscriptionUserRoles: []Role{
 			RoleVisitor,
 		},
 		DefaultEnabledUserRoles: []Role{
@@ -240,7 +240,7 @@ var (
 	NotificationEventChangeStatus = NotificationEvent{
 		UserSettingsKeyName: "event_notification_change_status",
 		DefaultSettingValue: strconv.Itoa(int(NotificationChannelWeb | NotificationChannelEmail)),
-		RequiresSubscripionUserRoles: []Role{
+		RequiresSubscriptionUserRoles: []Role{
 			RoleVisitor,
 		},
 		DefaultEnabledUserRoles: []Role{

--- a/app/models/identity.go
+++ b/app/models/identity.go
@@ -122,7 +122,7 @@ func (u *User) IsAdministrator() bool {
 	return u.Role == RoleAdministrator
 }
 
-//UserProvider represents the relashionship between an User and an Authentication provide
+//UserProvider represents the relationship between an User and an Authentication provide
 type UserProvider struct {
 	Name string
 	UID  string
@@ -180,7 +180,7 @@ type ImageUpload struct {
 	Remove bool             `json:"remove"`
 }
 
-//UpdateTenantSettingsLogoUpload is the input model used to uploade a new logo
+//UpdateTenantSettingsLogoUpload is the input model used to upload a new logo
 type ImageUploadData struct {
 	ContentType string `json:"contentType"`
 	Content     []byte `json:"content"`

--- a/app/pkg/assert/assert.go
+++ b/app/pkg/assert/assert.go
@@ -175,7 +175,7 @@ func (a *AnyAssertions) Panics() (panicked bool) {
 	return
 }
 
-//EventuallyEquals asserts that, withtin 30 seconds, the actual function will return same value as expected value
+//EventuallyEquals asserts that, within 30 seconds, the actual function will return same value as expected value
 func (a *AnyAssertions) EventuallyEquals(expected interface{}) bool {
 	mustBeFunction(a.actual)
 

--- a/app/pkg/dbx/mapping.go
+++ b/app/pkg/dbx/mapping.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//RowMapper is resposible for mapping a sql.Rows into a Struct (model)
+//RowMapper is responsible for mapping a sql.Rows into a Struct (model)
 type RowMapper struct {
 	cache map[reflect.Type]TypeMapper
 	sync.RWMutex

--- a/app/pkg/email/email.go
+++ b/app/pkg/email/email.go
@@ -117,13 +117,13 @@ var whitelistRegex = regexp.MustCompile(whitelist)
 var blacklist = env.GetEnvOrDefault("EMAIL_BLACKLIST", "")
 var blacklistRegex = regexp.MustCompile(blacklist)
 
-// SetWhitelist can be used to change email whitelist during rutime
+// SetWhitelist can be used to change email whitelist during runtime
 func SetWhitelist(s string) {
 	whitelist = s
 	whitelistRegex = regexp.MustCompile(whitelist)
 }
 
-// SetBlacklist can be used to change email blacklist during rutime
+// SetBlacklist can be used to change email blacklist during runtime
 func SetBlacklist(s string) {
 	blacklist = s
 	blacklistRegex = regexp.MustCompile(blacklist)

--- a/app/pkg/markdown/renderer.go
+++ b/app/pkg/markdown/renderer.go
@@ -125,7 +125,7 @@ func (r renderer) LineBreak(out *bytes.Buffer) {
 	out.Write([]byte{'\n'})
 }
 
-// Link is the link tag callback.  Outputs a sipmle plain-text version
+// Link is the link tag callback.  Outputs a simple plain-text version
 // of the input.
 func (r renderer) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
 	out.Write(content)

--- a/app/pkg/web/binder_test.go
+++ b/app/pkg/web/binder_test.go
@@ -221,7 +221,7 @@ func TestDefaultBinder_POST_CustomType(t *testing.T) {
 	Expect(u.TheSize64).Equals(Small64)
 }
 
-func TestDefaultBinder_POST_CustomType_Unmarshall(t *testing.T) {
+func TestDefaultBinder_POST_CustomType_Unmarshal(t *testing.T) {
 	RegisterT(t)
 
 	type pizza struct {

--- a/app/pkg/web/context.go
+++ b/app/pkg/web/context.go
@@ -28,7 +28,7 @@ type Map map[string]interface{}
 // StringMap defines a map of type `map[string]string`
 type StringMap map[string]string
 
-// Props defines the data required to rende rages
+// Props defines the data required to render rages
 type Props struct {
 	Title       string
 	Description string

--- a/app/pkg/web/context.go
+++ b/app/pkg/web/context.go
@@ -54,13 +54,13 @@ const CookieAuthName = "auth"
 const CookieSignUpAuthName = "__signup_auth"
 
 var (
-	preffixKey            = "__CTX_"
-	tenantContextKey      = preffixKey + "TENANT"
-	userContextKey        = preffixKey + "USER"
-	claimsContextKey      = preffixKey + "CLAIMS"
-	transactionContextKey = preffixKey + "TRANSACTION"
-	servicesContextKey    = preffixKey + "SERVICES"
-	tasksContextKey       = preffixKey + "TASKS"
+	prefixKey            = "__CTX_"
+	tenantContextKey      = prefixKey + "TENANT"
+	userContextKey        = prefixKey + "USER"
+	claimsContextKey      = prefixKey + "CLAIMS"
+	transactionContextKey = prefixKey + "TRANSACTION"
+	servicesContextKey    = prefixKey + "SERVICES"
+	tasksContextKey       = prefixKey + "TASKS"
 )
 
 //Context shared between http pipeline

--- a/app/pkg/web/engine.go
+++ b/app/pkg/web/engine.go
@@ -190,7 +190,7 @@ func (e *Engine) Database() *dbx.Database {
 	return e.db
 }
 
-//Worker returns current worker referenc
+//Worker returns current worker reference
 func (e *Engine) Worker() worker.Worker {
 	return e.worker
 }

--- a/app/storage/postgres/post.go
+++ b/app/storage/postgres/post.go
@@ -540,7 +540,7 @@ func (s *PostStorage) GetActiveSubscribers(number int, channel models.Notificati
 
 	var users []*dbUser
 
-	if len(event.RequiresSubscripionUserRoles) == 0 {
+	if len(event.RequiresSubscriptionUserRoles) == 0 {
 		err = s.trx.Select(&users, `
 			SELECT DISTINCT u.id, u.name, u.email, u.tenant_id, u.role, u.status
 			FROM users u
@@ -587,7 +587,7 @@ func (s *PostStorage) GetActiveSubscribers(number int, channel models.Notificati
 			s.tenant.ID,
 			pq.Array(event.DefaultEnabledUserRoles),
 			channel,
-			pq.Array(event.RequiresSubscripionUserRoles),
+			pq.Array(event.RequiresSubscriptionUserRoles),
 			models.UserActive,
 		)
 	}

--- a/app/storage/postgres/user.go
+++ b/app/storage/postgres/user.go
@@ -274,7 +274,7 @@ func (s *UserStorage) HasSubscribedTo(postID int) (bool, error) {
 
 	if errors.Cause(err) == app.ErrNotFound {
 		for _, e := range models.AllNotificationEvents {
-			for _, r := range e.RequiresSubscripionUserRoles {
+			for _, r := range e.RequiresSubscriptionUserRoles {
 				if r == s.user.Role {
 					return false, nil
 				}

--- a/public/components/common/Legal.tsx
+++ b/public/components/common/Legal.tsx
@@ -3,7 +3,7 @@ import { Modal, Checkbox } from "@fider/components/common";
 import { Fider } from "@fider/services";
 
 interface LegalAgreementProps {
-  onChange: (agrred: boolean) => void;
+  onChange: (agreed: boolean) => void;
 }
 
 export const TermsOfService: React.StatelessComponent<{}> = () => {

--- a/public/pages/Administration/pages/AdvancedSettings.page.tsx
+++ b/public/pages/Administration/pages/AdvancedSettings.page.tsx
@@ -58,7 +58,7 @@ export class AdvancedSettingsPage extends AdminBasePage<AdvancedSettingsPageProp
           <p className="info">
             Custom CSS allows you to change the look and feel of Fider so that you can apply your own branding.
             <br />
-            This is a powerful and flexibe feature, but requires basic understanding of{" "}
+            This is a powerful and flexible feature, but requires basic understanding of{" "}
             <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS">CSS</a>.
           </p>
           <p className="info">

--- a/public/pages/MySettings/components/APIKeyForm.tsx
+++ b/public/pages/MySettings/components/APIKeyForm.tsx
@@ -12,7 +12,7 @@ export class APIKeyForm extends React.Component<{}, APIKeyFormState> {
     this.state = {};
   }
 
-  private renegerate = async () => {
+  private regenerate = async () => {
     const result = await actions.regenerateAPIKey();
     if (result.ok) {
       this.setState({ apiKey: result.data.apiKey });
@@ -46,7 +46,7 @@ export class APIKeyForm extends React.Component<{}, APIKeyFormState> {
           .
         </p>
         <p>
-          <Button size="tiny" onClick={this.renegerate}>
+          <Button size="tiny" onClick={this.regenerate}>
             Regenerate API Key
           </Button>
         </p>

--- a/public/pages/ShowPost/components/ShowComment.tsx
+++ b/public/pages/ShowPost/components/ShowComment.tsx
@@ -10,7 +10,7 @@ interface ShowCommentProps {
 
 interface ShowCommentState {
   comment: Comment;
-  isEditting: boolean;
+  isEditing: boolean;
   newContent: string;
   error?: Failure;
 }
@@ -20,7 +20,7 @@ export class ShowComment extends React.Component<ShowCommentProps, ShowCommentSt
     super(props);
     this.state = {
       comment: props.comment,
-      isEditting: false,
+      isEditing: false,
       newContent: ""
     };
   }
@@ -33,12 +33,12 @@ export class ShowComment extends React.Component<ShowCommentProps, ShowCommentSt
   }
 
   private startEdit = () => {
-    this.setState({ isEditting: true, newContent: this.state.comment.content, error: undefined });
+    this.setState({ isEditing: true, newContent: this.state.comment.content, error: undefined });
   };
 
   private cancelEdit = async () => {
     this.setState({
-      isEditting: false,
+      isEditing: false,
       newContent: "",
       error: undefined
     });
@@ -83,7 +83,7 @@ export class ShowComment extends React.Component<ShowCommentProps, ShowCommentSt
             · <Moment date={c.createdAt} />
           </div>
           {editedMetadata}
-          {!this.state.isEditting &&
+          {!this.state.isEditing &&
             this.canEditComment(c) && (
               <div className="c-comment-metadata">
                 ·{" "}
@@ -93,7 +93,7 @@ export class ShowComment extends React.Component<ShowCommentProps, ShowCommentSt
               </div>
             )}
           <div className="c-comment-text">
-            {this.state.isEditting ? (
+            {this.state.isEditing ? (
               <Form error={this.state.error}>
                 <TextArea
                   field="content"

--- a/tests/lib/components.ts
+++ b/tests/lib/components.ts
@@ -17,13 +17,13 @@ export class WebComponent {
     );
   }
 
-  public async getAttribute(attibuteName: string): Promise<string> {
+  public async getAttribute(attributeName: string): Promise<string> {
     return await this.tab.evaluate<string>(
       (selector: string, attrName: string) => {
         const el = document.querySelector(selector) as HTMLElement | undefined;
         return el ? el.getAttribute(attrName) || "" : "";
       },
-      [this.selector, attibuteName]
+      [this.selector, attributeName]
     );
   }
 


### PR DESCRIPTION
There are a lot of typos in comments. Also, variable names and functions named not correct. This MR fixed these problems.