### PR TITLE
[fider/580] Burger menu is incorrectly positioned

### DIFF
--- a/public/assets/styles/grid.scss
+++ b/public/assets/styles/grid.scss
@@ -1,6 +1,7 @@
 // Container Size
 
 .container {
+  position: relative;
   display: block;
   max-width: 100% !important; 
 }

--- a/public/pages/Administration/components/SideMenu.scss
+++ b/public/pages/Administration/components/SideMenu.scss
@@ -1,7 +1,9 @@
 @import '~@fider/assets/styles/variables.scss';
 
 .c-side-menu-toggler {
-  float: right;
+  position: absolute;
+  top: 0;
+  right: 0;
   margin-top: 5px;
   cursor: pointer;
 


### PR DESCRIPTION
**Issue:**  #580 

Correctly position the burger menu collapser at the top right corner of the container that it is in.