### PR TITLE
[fider/581] Invalid posts should return a 404 and not a 500

### DIFF
--- a/app/cmd/routes.go
+++ b/app/cmd/routes.go
@@ -159,7 +159,7 @@ func routes(r *web.Engine) *web.Engine {
 		api.Use(middlewares.IsAuthenticated())
 
 		api.Post("/api/v1/posts", apiv1.CreatePost())
-                api.Get("/api/v1/posts/:number", apiv1.GetPost())
+		api.Get("/api/v1/posts/:number", apiv1.GetPost())
 		api.Post("/api/v1/posts/:number/comments", apiv1.PostComment())
 		api.Put("/api/v1/posts/:number/comments/:id", apiv1.UpdateComment())
 		api.Delete("/api/v1/posts/:number/comments/:id", apiv1.DeleteComment())

--- a/app/cmd/routes.go
+++ b/app/cmd/routes.go
@@ -154,12 +154,12 @@ func routes(r *web.Engine) *web.Engine {
 		api.Get("/api/v1/posts", apiv1.SearchPosts())
 		api.Get("/api/v1/tags", apiv1.ListTags())
 		api.Get("/api/v1/posts/:number/comments", apiv1.ListComments())
+		api.Get("/api/v1/posts/:number", apiv1.GetPost())
 
 		//From this step, a User is required
 		api.Use(middlewares.IsAuthenticated())
 
 		api.Post("/api/v1/posts", apiv1.CreatePost())
-		api.Get("/api/v1/posts/:number", apiv1.GetPost())
 		api.Post("/api/v1/posts/:number/comments", apiv1.PostComment())
 		api.Put("/api/v1/posts/:number/comments/:id", apiv1.UpdateComment())
 		api.Delete("/api/v1/posts/:number/comments/:id", apiv1.DeleteComment())

--- a/app/cmd/routes.go
+++ b/app/cmd/routes.go
@@ -159,6 +159,7 @@ func routes(r *web.Engine) *web.Engine {
 		api.Use(middlewares.IsAuthenticated())
 
 		api.Post("/api/v1/posts", apiv1.CreatePost())
+                api.Get("/api/v1/posts/:number", apiv1.GetPost())
 		api.Post("/api/v1/posts/:number/comments", apiv1.PostComment())
 		api.Put("/api/v1/posts/:number/comments/:id", apiv1.UpdateComment())
 		api.Delete("/api/v1/posts/:number/comments/:id", apiv1.DeleteComment())

--- a/app/handlers/apiv1/post.go
+++ b/app/handlers/apiv1/post.go
@@ -52,6 +52,23 @@ func CreatePost() web.HandlerFunc {
 	}
 }
 
+// GetPost retrieves the existing post by id
+func GetPost() web.HandlerFunc {
+        return func(c web.Context) error {
+		number, err := c.ParamAsInt("number")
+		if err != nil {
+			return c.NotFound()
+		}
+
+		post, err := c.Services().Posts.GetByNumber(number)
+		if err != nil {
+			return c.Failure(err)
+		}
+
+		return c.Ok(post)
+	}
+}
+
 // UpdatePost updates an existing post of current tenant
 func UpdatePost() web.HandlerFunc {
 	return func(c web.Context) error {
@@ -120,7 +137,7 @@ func ListComments() web.HandlerFunc {
 	return func(c web.Context) error {
 		number, err := c.ParamAsInt("number")
 		if err != nil {
-			return c.Failure(err)
+			return c.NotFound()
 		}
 
 		post, err := c.Services().Posts.GetByNumber(number)
@@ -228,7 +245,7 @@ func Unsubscribe() web.HandlerFunc {
 func addOrRemove(c web.Context, addOrRemove func(post *models.Post, user *models.User) error) error {
 	number, err := c.ParamAsInt("number")
 	if err != nil {
-		return c.Failure(err)
+		return c.NotFound()
 	}
 
 	post, err := c.Services().Posts.GetByNumber(number)

--- a/app/handlers/apiv1/post.go
+++ b/app/handlers/apiv1/post.go
@@ -52,7 +52,7 @@ func CreatePost() web.HandlerFunc {
 	}
 }
 
-// GetPost retrieves the existing post by id
+// GetPost retrieves the existing post by number
 func GetPost() web.HandlerFunc {
         return func(c web.Context) error {
 		number, err := c.ParamAsInt("number")

--- a/app/handlers/apiv1/post_test.go
+++ b/app/handlers/apiv1/post_test.go
@@ -51,15 +51,15 @@ func TestGetPostHandler(t *testing.T) {
 	services.SetCurrentUser(mock.JonSnow)
 	post, _ := services.Posts.Add("My First Post", "With a description")
 
-	code, post := server.
+	code, query := server.
 		OnTenant(mock.DemoTenant).
 		AsUser(mock.JonSnow).
 		AddParam("number", post.Number).
 		ExecuteAsJSON(apiv1.GetPost())
         
 	Expect(code).Equals(http.StatusOK)
-	Expect(post.Title).Equals("My First Post")
-	Expect(post.Description).Equals("With a description")       	
+	Expect(query.String("title")).Equals("My First Post")
+	Expect(query.String("description")).Equals("With a description")       	
 }
 
 func TestUpdatePostHandler_TenantStaff(t *testing.T) {

--- a/app/handlers/apiv1/post_test.go
+++ b/app/handlers/apiv1/post_test.go
@@ -43,6 +43,25 @@ func TestCreatePostHandler_WithoutTitle(t *testing.T) {
 	Expect(err).IsNotNil()
 }
 
+func TestGetPostHandler(t *testing.T) {
+	RegisterT(t)
+
+	server, services := mock.NewServer()
+	services.SetCurrentTenant(mock.DemoTenant)
+	services.SetCurrentUser(mock.JonSnow)
+	post, _ := services.Posts.Add("My First Post", "With a description")
+
+	code, post := server.
+		OnTenant(mock.DemoTenant).
+		AsUser(mock.JonSnow).
+		AddParam("number", post.Number).
+		ExecuteAsJSON(apiv1.GetPost())
+        
+	Expect(code).Equals(http.StatusOK)
+	Expect(post.Title).Equals("My First Post")
+	Expect(post.Description).Equals("With a description")       	
+}
+
 func TestUpdatePostHandler_TenantStaff(t *testing.T) {
 	RegisterT(t)
 
@@ -425,21 +444,4 @@ func TestListCommentHandler(t *testing.T) {
 	Expect(code).Equals(http.StatusOK)
 	Expect(query.IsArray()).IsTrue()
 	Expect(query.ArrayLength()).Equals(2)
-}
-
-func TestGetPostHandler(t *testing.T) {
-	RegisterT(t)
-
-	server, services := mock.NewServer()
-	services.SetCurrentTenant(mock.DemoTenant)
-	services.SetCurrentUser(mock.JonSnow)
-	post, _ := services.Posts.Add("My First Post", "With a description")
-
-	code, query := server.
-		OnTenant(mock.DemoTenant).
-		AsUser(mock.JonSnow).
-		AddParam("number", post.Number).
-		ExecuteAsJSON(apiv1.GetPost())
-
-	Expect(code).Equals(http.StatusOK)
 }

--- a/app/handlers/apiv1/post_test.go
+++ b/app/handlers/apiv1/post_test.go
@@ -442,6 +442,5 @@ func TestGetPostHandler(t *testing.T) {
 		ExecuteAsJSON(apiv1.GetPost())
 
 	Expect(code).Equals(http.StatusOK)
-	Expect(query.IsArray()).IsTrue()
-	Expect(query.ArrayLength()).Equals(2)
+	Expect(query.Title).Equals('My First Post')
 }

--- a/app/handlers/apiv1/post_test.go
+++ b/app/handlers/apiv1/post_test.go
@@ -49,7 +49,7 @@ func TestGetPostHandler(t *testing.T) {
 	server, services := mock.NewServer()
 	services.SetCurrentTenant(mock.DemoTenant)
 	services.SetCurrentUser(mock.JonSnow)
-	post, _ := services.Posts.Add("My First Post", "With a description")
+	post, _ := services.Posts.Add("My First Post", "Such an amazing description")
 
 	code, query := server.
 		OnTenant(mock.DemoTenant).
@@ -59,7 +59,7 @@ func TestGetPostHandler(t *testing.T) {
         
 	Expect(code).Equals(http.StatusOK)
 	Expect(query.String("title")).Equals("My First Post")
-	Expect(query.String("description")).Equals("With a description")       	
+	Expect(query.String("description")).Equals("Such an amazing description")	
 }
 
 func TestUpdatePostHandler_TenantStaff(t *testing.T) {

--- a/app/handlers/apiv1/post_test.go
+++ b/app/handlers/apiv1/post_test.go
@@ -426,3 +426,22 @@ func TestListCommentHandler(t *testing.T) {
 	Expect(query.IsArray()).IsTrue()
 	Expect(query.ArrayLength()).Equals(2)
 }
+
+func TestGetPostHandler(t *testing.T) {
+	RegisterT(t)
+
+	server, services := mock.NewServer()
+	services.SetCurrentTenant(mock.DemoTenant)
+	services.SetCurrentUser(mock.JonSnow)
+	post, _ := services.Posts.Add("My First Post", "With a description")
+
+	code, query := server.
+		OnTenant(mock.DemoTenant).
+		AsUser(mock.JonSnow).
+		AddParam("number", post.Number).
+		ExecuteAsJSON(apiv1.GetPost())
+
+	Expect(code).Equals(http.StatusOK)
+	Expect(query.IsArray()).IsTrue()
+	Expect(query.ArrayLength()).Equals(2)
+}

--- a/app/handlers/apiv1/post_test.go
+++ b/app/handlers/apiv1/post_test.go
@@ -442,5 +442,4 @@ func TestGetPostHandler(t *testing.T) {
 		ExecuteAsJSON(apiv1.GetPost())
 
 	Expect(code).Equals(http.StatusOK)
-	Expect(query.Title).Equals('My First Post')
 }

--- a/app/handlers/post.go
+++ b/app/handlers/post.go
@@ -52,7 +52,7 @@ func PostDetails() web.HandlerFunc {
 	return func(c web.Context) error {
 		number, err := c.ParamAsInt("number")
 		if err != nil {
-			return c.Failure(err)
+			return c.NotFound()
 		}
 
 		posts := c.Services().Posts


### PR DESCRIPTION
**Issue:**  #581 

- Adjust the handlers to send back a 404 if the `ParamAsInt("number")` validation fails.
- Add an endpoint to retrieve a post (Rest)