### PR TITLE
title validate support Chinese and Japanese

### DIFF
--- a/app/actions/post.go
+++ b/app/actions/post.go
@@ -33,7 +33,7 @@ func (input *CreateNewPost) Validate(user *models.User, services *app.Services) 
 
 	if input.Model.Title == "" {
 		result.AddFieldFailure("title", "Title is required.")
-	} else if len(input.Model.Title) < 10 || len(strings.Split(input.Model.Title, " ")) < 3 {
+	} else if len(input.Model.Title) < 10 {
 		result.AddFieldFailure("title", "Title needs to be more descriptive.")
 	}
 


### PR DESCRIPTION
**Issue:**  <!-- What's this PR for? Link it to a GitHub issue or create one before you submit this Pull Request. -->
When I type in Chinese the system cannot be used as easy as in English, just like when I edit the title. 

<!-- Briefly explain what is being changed with this Pull Request. -->

I just remove `|| len(strings.Split(input.Model.Title, " ")) < 3` because I think it is unnecessary when support other language.