### PR TITLE
fix: older browsers cannot execute inline javascript with CSP

### DIFF
--- a/app/pkg/web/renderer.go
+++ b/app/pkg/web/renderer.go
@@ -92,10 +92,7 @@ func (r *Renderer) Render(w io.Writer, name string, props Props, ctx *Context) {
 		tmpl = r.add(name)
 	}
 
-	m := props.Data
-	if m == nil {
-		m = make(Map, 0)
-	}
+	m := make(Map, 0)
 
 	tenantName := "Fider"
 	if ctx.Tenant() != nil {
@@ -123,6 +120,7 @@ func (r *Renderer) Render(w io.Writer, name string, props Props, ctx *Context) {
 	m["__contextID"] = ctx.ContextID()
 	m["__currentURL"] = ctx.Request.URL.String()
 	m["__tenant"] = ctx.Tenant()
+	m["__props"] = props.Data
 
 	oauthProviders := make([]*oauth.ProviderOption, 0)
 	if !ctx.IsAuthenticated() && ctx.Services() != nil {

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -33,18 +33,10 @@ window.addEventListener("error", (evt: ErrorEvent) => {
     return;
   }
 
-  try {
-    fider = Fider.initialize();
+  fider = Fider.initialize();
 
-    __webpack_nonce__ = fider.session.contextID;
-    __webpack_public_path__ = `${fider.settings.globalAssetsURL}/assets/`;
-  } catch (err) {
-    actions
-      .logError(err.message || "An unhandled error occurred", err.error)
-      .then(() => navigator.goTo("/browser-not-supported"))
-      .catch(() => navigator.goTo("/browser-not-supported"));
-    return;
-  }
+  __webpack_nonce__ = fider.session.contextID;
+  __webpack_public_path__ = `${fider.settings.globalAssetsURL}/assets/`;
 
   const config = resolveRootComponent(location.pathname);
   document.body.className = classSet({

--- a/public/services/fider.ts
+++ b/public/services/fider.ts
@@ -6,11 +6,11 @@ export class FiderSession {
   private pUser: CurrentUser | undefined;
   private pProps: { [key: string]: any } = {};
 
-  constructor() {
-    this.pContextID = window.__contextID;
-    this.pProps = window.__props;
-    this.pUser = window.__user;
-    this.pTenant = window.__tenant;
+  constructor(data: any) {
+    this.pContextID = data.__contextID;
+    this.pProps = data.__props;
+    this.pUser = data.__user;
+    this.pTenant = data.__tenant;
   }
 
   public get contextID(): string {
@@ -39,8 +39,10 @@ export class FiderImpl {
   private pSession!: FiderSession;
 
   public initialize = (): FiderImpl => {
-    this.pSettings = window.__settings;
-    this.pSession = new FiderSession();
+    const el = document.getElementById("server-data")!;
+    const data = JSON.parse(el.innerText);
+    this.pSettings = data.__settings;
+    this.pSession = new FiderSession(data);
     return this;
   };
 

--- a/public/services/fider.ts
+++ b/public/services/fider.ts
@@ -39,8 +39,8 @@ export class FiderImpl {
   private pSession!: FiderSession;
 
   public initialize = (): FiderImpl => {
-    const el = document.getElementById("server-data")!;
-    const data = JSON.parse(el.innerText);
+    const el = document.getElementById("server-data");
+    const data = el ? JSON.parse(el.innerText) : {};
     this.pSettings = data.__settings;
     this.pSession = new FiderSession(data);
     return this;

--- a/public/tsd.d.ts
+++ b/public/tsd.d.ts
@@ -4,11 +4,6 @@ declare global {
   interface Window {
     ga?: (cmd: string, evt: string, args?: any) => void;
     set: (key: string, value: any) => void;
-    __props: { [key: string]: any };
-    __contextID: string;
-    __user: CurrentUser | undefined;
-    __tenant: Tenant;
-    __settings: SystemSettings;
   }
 
   var __webpack_nonce__: string; // tslint:disable-line

--- a/views/403.html
+++ b/views/403.html
@@ -1,4 +1,4 @@
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
   <div class="container failure-page">

--- a/views/404.html
+++ b/views/404.html
@@ -1,4 +1,4 @@
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
   <div class="container failure-page">

--- a/views/410.html
+++ b/views/410.html
@@ -1,4 +1,4 @@
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
   <div class="container failure-page">

--- a/views/500.html
+++ b/views/500.html
@@ -1,4 +1,4 @@
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
         
 {{define "content"}}
   <div class="container failure-page">

--- a/views/base.html
+++ b/views/base.html
@@ -44,8 +44,8 @@
 
   {{template "content" .}}
 
-  <script type="text/javascript" nonce="{{ .__contextID }}">
-    {{template "javascript" .}}
+  <script id="server-data" type="application/json">
+    {{template "server-data" .}}
   </script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,fetch" crossorigin="anonymous"></script>
   <script src="{{ .__vendorBundle }}" crossorigin="anonymous"></script>

--- a/views/browser-not-supported.html
+++ b/views/browser-not-supported.html
@@ -2,7 +2,7 @@
 Browser not supported &middot; Fider
 {{end}}
       
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
 <div class="container failure-page">

--- a/views/index.html
+++ b/views/index.html
@@ -1,13 +1,7 @@
 // Print all variables that does not start with _ (95)
 // Compressed to avoid whitespace being printed
-{{define "javascript"}} 
-    {{ if .__user }}window.__user = {{ .__user }};{{ end }}
-    window.__contextID = {{ .__contextID }};
-    window.__settings = {{ .__settings }};
-    window.__tenant = {{ .__tenant }};
-    window.__props = {};
-{{ range $key, $value := . }}{{ $first := index $key 1 }}{{ if ne $first 95 }}
-    window.__props['{{ $key }}'] = {{ $value }};{{ end }}{{ end }} {{end}}
-        
+{{define "server-data"}} 
+    {{ . }}
+{{ end }}
 {{define "content"}}<div id="root"></div><div id="root-modal"></div>{{end}}
 {{define "end-of-body"}}<script src="{{ .__jsBundle }}" crossorigin="anonymous"></script>{{end}}

--- a/views/legal.html
+++ b/views/legal.html
@@ -2,7 +2,7 @@
 
 {{define "content"}}
   <div class="container legal-page">
-    {{ .Content | markdown }}
+    {{ .__props.Content | markdown }}
   </div>
 {{end}}
 

--- a/views/legal.html
+++ b/views/legal.html
@@ -1,4 +1,4 @@
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
   <div class="container legal-page">

--- a/views/not-invited.html
+++ b/views/not-invited.html
@@ -2,7 +2,7 @@
 Not Invited &middot; Fider
 {{end}}
       
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
 <div class="container failure-page">

--- a/views/pending-activation.html
+++ b/views/pending-activation.html
@@ -2,7 +2,7 @@
 Pending Activation &middot; Fider
 {{end}}
       
-{{define "javascript"}}{{end}}
+{{define "server-data"}}{{end}}
 
 {{define "content"}}
 <div class="container failure-page">


### PR DESCRIPTION
Replace our inline javascript with a JSON payload that is then parsed by our external script.