### PR TITLE
Allow heroku deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 output/
 node_modules/
 .vscode/
+.idea/
 logs/
 
 fider

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,3 +61,7 @@ ignored = ["github.com/magefile/mage/mg","github.com/magefile/mage/sh"]
   branch = "master"
   name = "github.com/joeshaw/envdecode"
 
+[metadata.heroku]
+  root-package = "github.com/getfider/fider"
+  go-version = "1.12"
+  install = [ "./..." ]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ./bin/fider migrate && ./bin/fider

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,7 @@
+build:
+  languages:
+    - nodejs
+    - go
+
+run:
+  web: ./bin/fider migrate && ./bin/fider

--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
       "^.*\\.(png|scss|svg)$": "<rootDir>/public/jest.assets.ts",
       "@fider/(.*)": "<rootDir>/public/$1"
     }
+  },
+  "scripts":{
+    "heroku-postbuild": "npx webpack -p"
   }
 }


### PR DESCRIPTION
**New feature:**  

This will allow deploying a fider application really easily on Heroku, allowing users to test the application without any line of code, or even to deploy a fully-functioning fider instance for $0.

Steps to deploy on heroku:
- Fork the repository (for auto-deployment from your github account) or clone it locally
- Create an Heroku app : https://dashboard.heroku.com/new-app
- Add a Postgresql add-on on the app (https://elements.heroku.com/addons/heroku-postgresql)
- Add Go buildpack : https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-go
- Add Nodejs buildpack : https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-nodejs
- Setup application's environment variables on Heroku (I'm using mailgun but use SMTP equivalent if needed) : `EMAIL_MAILGUN_API`, `EMAIL_MAILGUN_DOMAIN`, `EMAIL_MAILGUN_REGION`, `EMAIL_NOREPLY`, and `JWT_SECRET` (`DATABASE_URL` will already be set up by the Postgresql add-on).
- Deploy your app on Heroku
- Enjoy 🎉 

This would, IMHO, be a nice alternative in the `hosting your instance` way in the documentation (https://getfider.com/docs/hosting-instance/) If you like the idea, I will do the PR on the documentation.

Thanks and great work on this great application!