### PR TITLE
app/models: extract side effects

### DIFF
--- a/app/models/identity.go
+++ b/app/models/identity.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/getfider/fider/app/models/enum"
-	"github.com/getfider/fider/app/pkg/jwt"
+	"github.com/getfider/fider/app/models/jwt"
 	"github.com/getfider/fider/app/pkg/rand"
 )
 

--- a/app/models/jwt/jwt.go
+++ b/app/models/jwt/jwt.go
@@ -1,0 +1,26 @@
+package jwt
+
+import (
+	jwtgo "github.com/dgrijalva/jwt-go"
+)
+
+// Metadata is the basic JWT information
+type Metadata = jwtgo.StandardClaims
+
+// FiderClaims represents what goes into JWT tokens
+type FiderClaims struct {
+	UserID    int    `json:"user/id"`
+	UserName  string `json:"user/name"`
+	UserEmail string `json:"user/email"`
+	Origin    string `json:"origin"`
+	Metadata
+}
+
+// OAuthClaims represents what goes into temporary OAuth JWT tokens
+type OAuthClaims struct {
+	OAuthID       string `json:"oauth/id"`
+	OAuthProvider string `json:"oauth/provider"`
+	OAuthName     string `json:"oauth/name"`
+	OAuthEmail    string `json:"oauth/email"`
+	Metadata
+}

--- a/app/pkg/jwt/jwt.go
+++ b/app/pkg/jwt/jwt.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	jwtgo "github.com/dgrijalva/jwt-go"
+	models "github.com/getfider/fider/app/models/jwt"
 	"github.com/getfider/fider/app/pkg/env"
 	"github.com/getfider/fider/app/pkg/errors"
 )
@@ -19,22 +20,10 @@ const (
 )
 
 // FiderClaims represents what goes into JWT tokens
-type FiderClaims struct {
-	UserID    int    `json:"user/id"`
-	UserName  string `json:"user/name"`
-	UserEmail string `json:"user/email"`
-	Origin    string `json:"origin"`
-	Metadata
-}
+type FiderClaims = models.FiderClaims
 
 // OAuthClaims represents what goes into temporary OAuth JWT tokens
-type OAuthClaims struct {
-	OAuthID       string `json:"oauth/id"`
-	OAuthProvider string `json:"oauth/provider"`
-	OAuthName     string `json:"oauth/name"`
-	OAuthEmail    string `json:"oauth/email"`
-	Metadata
-}
+type OAuthClaims = models.OAuthClaims
 
 // Encode creates new JWT token with given claims
 func Encode(claims jwtgo.Claims) (string, error) {


### PR DESCRIPTION
**Issue:**  #848

Currently importing app/models triggers app/pkg/jwt, which causes the
init in app/pkg/env to invoke. While this may be a foregone conclusion
in some contexts, data models should be pure.

This change extracts the jwt model into a new package app/models/jwt,
while forwarding all refrences, except app/models.CreateTenant, through
the old app/pkg/jwt, to reduce noise and because one package is a
better interface than two.