### PR TITLE
security: replace math/rand with crypto/rand to generate secret strings

### DIFF
--- a/app/pkg/rand/random.go
+++ b/app/pkg/rand/random.go
@@ -1,13 +1,9 @@
 package rand
 
 import (
-	"math/rand"
-	"time"
+	"crypto/rand"
+	"math/big"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 var chars = []byte("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
@@ -18,8 +14,13 @@ func String(n int) string {
 	}
 
 	bytes := make([]byte, n)
+	charsetLen := big.NewInt(int64(len(chars)))
 	for i := 0; i < n; i++ {
-		bytes[i] = chars[rand.Intn(len(chars))]
+		c, err := rand.Int(rand.Reader, charsetLen)
+		if err != nil {
+			panic(err)
+		}
+		bytes[i] = chars[c.Int64()]
 	}
 
 	return string(bytes)


### PR DESCRIPTION
**Issue:**  secret tokens, including session cookies and signin tokens sent by email, are generated with `rand.String` method, which uses the `math/rand` pseudrandom number generator. As stated in the Go [documentation](https://golang.org/pkg/math/rand/), this package is not suited to generate sensitive data.

This Pull Request replaces the underlying PRNG (`math/rand`) with `crypto/rand`, a cryptographically secure PRNG.