### PR TITLE
fix: removed auto-lower on URLs (OAuth)

### DIFF
--- a/app/actions/oauth.go
+++ b/app/actions/oauth.go
@@ -23,10 +23,10 @@ type CreateEditOAuthConfig struct {
 	DisplayName       string           `json:"displayName"`
 	ClientID          string           `json:"clientID"`
 	ClientSecret      string           `json:"clientSecret"`
-	AuthorizeURL      string           `json:"authorizeURL" format:"lower"`
-	TokenURL          string           `json:"tokenURL" format:"lower"`
+	AuthorizeURL      string           `json:"authorizeURL"`
+	TokenURL          string           `json:"tokenURL"`
 	Scope             string           `json:"scope"`
-	ProfileURL        string           `json:"profileURL" format:"lower"`
+	ProfileURL        string           `json:"profileURL"`
 	JSONUserIDPath    string           `json:"jsonUserIDPath"`
 	JSONUserNamePath  string           `json:"jsonUserNamePath"`
 	JSONUserEmailPath string           `json:"jsonUserEmailPath"`

--- a/app/pkg/validate/general.go
+++ b/app/pkg/validate/general.go
@@ -33,8 +33,6 @@ func Email(email string) []string {
 
 //URL validates given URL
 func URL(rawurl string) []string {
-	rawurl = strings.ToLower(rawurl)
-
 	if len(rawurl) > 300 {
 		return []string{"URL address must have less than 300 characters."}
 	}


### PR DESCRIPTION
**Issue:** #880 

Removed the automatic lowercase on OAuth `AuthorizeURL`, `TokenURL` and `ProfileURL`, as URLs are case-sensitive
