### PR TITLE
Implement "truncate" template function

### DIFF
--- a/app/pkg/tpl/funcs.go
+++ b/app/pkg/tpl/funcs.go
@@ -66,6 +66,12 @@ var templateFunctions = map[string]interface{}{
 		quoted := quote(text)
 		return quoted[1 : len(quoted)-1]
 	},
+	"truncate": func(input string, length int) string {
+		if len([]rune(input)) > length {
+			input = string([]rune(input)[:length-3]) + "..."
+		}
+		return input
+	},
 }
 
 func quote(text interface{}) string {

--- a/public/pages/Administration/components/webhook/WebhookTemplateInfoModal.tsx
+++ b/public/pages/Administration/components/webhook/WebhookTemplateInfoModal.tsx
@@ -78,6 +78,13 @@ const functions: StringObject<FunctionSpecification> = {
     description: "Encode a string into a valid URL query element",
     info: "You should use this function when using a value in URL",
   },
+  truncate: {
+    params: [
+      { type: "string", desc: "The input string to truncate" },
+      { type: "number", desc: "Length of output string" },
+    ],
+    description: "Truncate the string",
+  },
 }
 const textExample = 'A new post entitled "{{ .post_title }}" has been created by {{ .author_name }}.'
 const jsonExample = `{


### PR DESCRIPTION
**Issue:** #1026

I've implemented `truncate` function that can be used in templates to shorten strings. It accepts *string* as first argument and *max length* as the second one. If given *string* is longer than *max length*, it truncates it and adds ellipsis at the end, so output string will have length that equal to *max length* argument.

This can be used to forward messages to services that have a limit on message length. For example, webhook for Discord will look like this:
```
{
    "content": "",
    "embeds": [
        {
            "title": {{ quote .post_title }},
            "type": "rich",
            "description": "{{ truncate (escape .post_description) 4000 }}",
            "url": {{ quote .post_url }},
            "author": {
                "name": {{ quote .author_name }},
                "icon_url": {{ quote .author_avatar }}
            }
        }
    ]
}
```

In this example `{{ truncate .post_description 4000 | quote }}` will not work because `quote` function escapes the post description and the final text will be longer than 4000 symbols if input text has special characters such as line breaks.