### PR TITLE
Adding InsecureSkipVerify parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN mkdir /server
 WORKDIR /server
 
 COPY . .
-RUN BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 make build-server
+RUN go env -w GOPROXY=https://goproxy.cn,direct \
+    && BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 make build-server
 
 #################
 ### UI Build Step
@@ -20,7 +21,8 @@ RUN mkdir /ui
 WORKDIR /ui
 
 COPY . .
-RUN npm ci
+RUN npm config set registry http://registry.npm.taobao.org/ \
+    && npm ci
 RUN make build-ssr
 RUN make build-ui
 

--- a/app/models/enum/avatar.go
+++ b/app/models/enum/avatar.go
@@ -7,7 +7,7 @@ var (
 	//AvatarTypeLetter is the default avatar type for users
 	AvatarTypeLetter AvatarType = 1
 	//AvatarTypeGravatar fetches avatar from gravatar (if available)
-	AvatarTypeGravatar AvatarType = 2
+	AvatarTypeGravatar AvatarType = 1
 	//AvatarTypeCustom uses a user uploaded avatar
 	AvatarTypeCustom AvatarType = 3
 )

--- a/app/models/enum/avatar.go
+++ b/app/models/enum/avatar.go
@@ -7,7 +7,7 @@ var (
 	//AvatarTypeLetter is the default avatar type for users
 	AvatarTypeLetter AvatarType = 1
 	//AvatarTypeGravatar fetches avatar from gravatar (if available)
-	AvatarTypeGravatar AvatarType = 1
+	AvatarTypeGravatar AvatarType = 2
 	//AvatarTypeCustom uses a user uploaded avatar
 	AvatarTypeCustom AvatarType = 3
 )

--- a/app/pkg/env/env.go
+++ b/app/pkg/env/env.go
@@ -102,6 +102,7 @@ type config struct {
 			Username       string `env:"EMAIL_SMTP_USERNAME"`
 			Password       string `env:"EMAIL_SMTP_PASSWORD"`
 			EnableStartTLS bool   `env:"EMAIL_SMTP_ENABLE_STARTTLS,default=true"`
+			SkipVerifyCert bool   `env:"EMAIL_SMTP_CERT_SKIPVERIFY,default=false"`
 		}
 	}
 	BlobStorage struct {

--- a/app/services/sqlstore/postgres/user.go
+++ b/app/services/sqlstore/postgres/user.go
@@ -281,7 +281,7 @@ func registerUser(ctx context.Context, c *cmd.RegisterUser) error {
 		c.User.Email = strings.ToLower(strings.TrimSpace(c.User.Email))
 		if err := trx.Get(&c.User.ID,
 			"INSERT INTO users (name, email, created_at, tenant_id, role, status, avatar_type, avatar_bkey) VALUES ($1, $2, $3, $4, $5, $6, $7, '') RETURNING id",
-			c.User.Name, c.User.Email, now, tenant.ID, c.User.Role, enum.UserActive, enum.AvatarTypeGravatar); err != nil {
+			c.User.Name, c.User.Email, now, tenant.ID, c.User.Role, enum.UserActive, enum.AvatarTypeLetter); err != nil {
 			return errors.Wrap(err, "failed to register new user")
 		}
 


### PR DESCRIPTION
client verifies the server's certificate chain and host name. Adding this parameter is convenient for users of self-signed certificates.