### PR TITLE
Fix: Healthcheck errors if Host Domain set

### DIFF
--- a/app/cmd/ping.go
+++ b/app/cmd/ping.go
@@ -11,6 +11,10 @@ import (
 //RunPing checks if Fider Server is running and is healthy
 //Returns an exitcode, 0 for OK and 1 for ERROR
 func RunPing() int {
+
+	client := &http.Client{}
+
+	host := "localhost:" + env.Config.Port
 	protocol := "http://"
 	if env.Config.TLS.Certificate != "" || env.Config.TLS.Automatic {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
@@ -19,12 +23,18 @@ func RunPing() int {
 		protocol = "https://"
 	}
 
-	host := "localhost:" + env.Config.Port
-	if env.IsSingleHostMode() && len(env.Config.HostDomain) > 0 {
-		host = env.Config.HostDomain
+	req, err := http.NewRequest("GET", protocol+host+"/_health", nil)
+	if err != nil {
+		fmt.Printf("Setting up request failed with: %s", err)
+		return 1
 	}
 
-	resp, err := http.Get(protocol + host + "/_health")
+	// Set Host if HostDomain is set
+	if env.IsSingleHostMode() && len(env.Config.HostDomain) > 0 {
+		req.Header.Set("Host", env.Config.HostDomain)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Printf("Request failed with: %s\n", err)
 		return 1

--- a/app/cmd/ping.go
+++ b/app/cmd/ping.go
@@ -31,7 +31,7 @@ func RunPing() int {
 
 	// Set Host if HostDomain is set
 	if env.IsSingleHostMode() && len(env.Config.HostDomain) > 0 {
-		req.Header.Set("Host", env.Config.HostDomain)
+		req.Host = env.Config.HostDomain
 	}
 
 	resp, err := client.Do(req)

--- a/app/cmd/ping.go
+++ b/app/cmd/ping.go
@@ -19,7 +19,12 @@ func RunPing() int {
 		protocol = "https://"
 	}
 
-	resp, err := http.Get(protocol + "localhost:3000/_health")
+	host := "localhost:" + env.Config.Port
+	if env.IsSingleHostMode() && len(env.Config.HostDomain) > 0 {
+		host = env.Config.HostDomain
+	}
+
+	resp, err := http.Get(protocol + host + "/_health")
 	if err != nil {
 		fmt.Printf("Request failed with: %s\n", err)
 		return 1


### PR DESCRIPTION
Updated Ping command to fix health check errors

**Issue:** https://github.com/getfider/fider/issues/1047

When Host Domain is set, the Docker health check used to return errors.
This PR fixes that issue and also adds support for health checks if the app is running on ports other than the default 3000.