### PR TITLE
Add one-click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The easiest and quickest way to get started. A fully managed services by the cre
 
 You can also install Fider yourself. It's free, but you are responsible for managing it. [Learn how](https://fider.io/docs/hosting-instance)
 
+Deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=fider):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=fider)
+
 <br/>
 <br/>
 


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://fider-3074.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.