### PR TITLE
fix: setting default "view" query params to "all"

### DIFF
--- a/app/handlers/apiv1/post.go
+++ b/app/handlers/apiv1/post.go
@@ -15,9 +15,13 @@ import (
 // SearchPosts return existing posts based on search criteria
 func SearchPosts() web.HandlerFunc {
 	return func(c *web.Context) error {
+		viewQueryParams := c.QueryParam("view")
+		if viewQueryParams == "" {
+			viewQueryParams = "all" // Set default value to "all" if not provided
+		}
 		searchPosts := &query.SearchPosts{
 			Query: c.QueryParam("query"),
-			View:  c.QueryParam("view"),
+			View:  viewQueryParams,
 			Limit: c.QueryParam("limit"),
 			Tags:  c.QueryParamAsArray("tags"),
 		}


### PR DESCRIPTION
**Issue:** https://github.com/getfider/fider/issues/1143

<!-- Briefly explain what is being changed with this Pull Request. -->
**Reasoning behind bug:** In the code for getViewData, by default statuses only contains "open", "started" and "planned", since  https://fider.io/docs/api#list-posts also uses the same function to generate the sql, the returned posts will only have "open", "started" and "planned" statuses. This conflicts with the documentations.

https://github.com/getfider/fider/blob/e55a144ab4aaeed1383bf0d9367cd80bfb7ec4a2/app/services/sqlstore/postgres/common.go#L33-L37

**Proposed changes:**
Since the getViewData function is used across the app, updating statuses here might cause problems on other parts of the app, I decided to create a conditional on the route handler for the API to always set the view Query Params to "all" if it is not specified. 
