### PR TITLE
Fix: changing go version in go.mod back to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 
 module github.com/getfider/fider
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go v1.41.14


### PR DESCRIPTION
**Issue:** <!-- What's this PR for? Link it to a GitHub issue or create one before you submit this Pull Request. -->

Sorry I was not able to push this change in time before https://github.com/getfider/fider/pull/1176 's merge

<!-- Briefly explain what is being changed with this Pull Request. -->
**Description of changes:**
- Changed version in go.mod to 1.22.0

**Reasoning:**
- The error on my end ```invalid go version '1.22.0': must match format 1.23``` was caused by my go version being 1.19, I updated to 1.22 and the error is gone, I have changed the version in ```go.mod``` back to 1.22.0.
