### PR TITLE
Update contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you know these technologies or would like to learn them, lucky you! This is t
 4. run `go install github.com/joho/godotenv/cmd/godotenv` to install godotenv, a cli tool to load environment variables from a `.env` so that you don't have to change your machine environment variables.
 5. run `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1` to install golangci-lint, a linter for Go apps.
 6. run `npm install` to install client side packages.
-7. run `docker-compose up -d` to start a local PostgreSQL database and Local SMTP (with [MailHog](https://github.com/mailhog/MailHog)) on Docker.
+7. run `docker compose up -d` to start a local PostgreSQL database and Local SMTP (with [MailHog](https://github.com/mailhog/MailHog)) on Docker.
 8. run `cp .example.env .env` to create a local environment configuration file.
 
 - **Important:** Fider has a strong dependency on an email delivery service. For easier local development, the docker-compose file already provides

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ## This is a self-documented Makefile. For usage information, run `make help`:
 ##
-## For more information, refer to https://suva.sh/posts/well-documented-makefiles/
+## For more information, refer to https://www.thapaliya.com/en/writings/well-documented-makefiles/
 
 LDFLAGS += -X github.com/getfider/fider/app/pkg/env.commithash=${COMMITHASH}
 


### PR DESCRIPTION
Hello ! 

### Description

Update contributing guide to be compliant with [Docker compose V2](https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2) by changing command `docker-compose` to `docker compose`

Update 404 link in the `Makefile` : 
* [404 Link](https://www.thapaliya.com/posts/well-documented-makefiles/) to [New link](https://www.thapaliya.com/en/writings/well-documented-makefiles/)

### Note 

Just a small PR while reading the contributing guide for the first time, I did not open any issue for this (should I ?)