### PR TITLE
Update Markdown dependency and Dockerfile to Debian Bookworm / Node.js 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #####################
 ### Server Build Step
 #####################
-FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.22-bullseye AS server-builder 
+FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.22-bookworm AS server-builder 
 
 
 RUN mkdir /server
@@ -18,7 +18,7 @@ RUN COMMITHASH=${COMMITHASH} GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-se
 #################
 ### UI Build Step
 #################
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:18-bullseye AS ui-builder 
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:22-bookworm AS ui-builder 
 
 WORKDIR /ui
 
@@ -32,7 +32,7 @@ RUN make build-ui
 ################
 ### Runtime Step
 ################
-FROM --platform=${TARGETPLATFORM:-linux/amd64} debian:bullseye-slim
+FROM --platform=${TARGETPLATFORM:-linux/amd64} debian:bookworm-slim
 
 RUN apt-get update
 RUN apt-get install -y ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/goenning/letteravatar v0.0.0-20180605200324-553181ed4055
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golangci/golangci-lint v1.59.1
-	github.com/gomarkdown/markdown v0.0.0-20220527210340-c82b80a9daf2
+	github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8
 	github.com/gosimple/slug v1.11.0
 	github.com/gotnospirit/messageformat v0.0.0-20190719172517-c1d0bdacdea2
 	github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/golangci/revgrep v0.5.3 h1:3tL7c1XBMtWHHqVpS5ChmiAAoe4PF/d5+ULzV9sLAz
 github.com/golangci/revgrep v0.5.3/go.mod h1:U4R/s9dlXZsg8uJmaR1GrloUr14D7qDl8gi2iPXJH8k=
 github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed h1:IURFTjxeTfNFP0hTEi1YKjB/ub8zkpaOqFFMApi2EAs=
 github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed/go.mod h1:XLXN8bNw4CGRPaqgl3bv/lhz7bsGPh4/xSaMTbo2vkQ=
-github.com/gomarkdown/markdown v0.0.0-20220527210340-c82b80a9daf2 h1:VJwys0mqRBeVxECc/DyXgveOqOqI81J9sjQFZHZwJvs=
-github.com/gomarkdown/markdown v0.0.0-20220527210340-c82b80a9daf2/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8 h1:4txT5G2kqVAKMjzidIabL/8KqjIK71yj30YOeuxLn10=
+github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=


### PR DESCRIPTION
**Issue:** #1145

- Changed the runtime base image from Debian Bullseye to Debian Bookworm for better security and package support.
- Upgraded Node.js version from 18 to 22 in the UI build step for improved performance and compatibility with newer features.
- Updated Go library `github.com/gomarkdown/markdown` to fix [CVE-2023-42821](https://nvd.nist.gov/vuln/detail/CVE-2023-42821).
