### PR TITLE
Add Upsun.com hosting support

### DIFF
--- a/.environment
+++ b/.environment
@@ -1,0 +1,23 @@
+# Set database environment variables
+export DB_HOST="$POSTGRESQL_HOST"
+export DB_PORT="$POSTGRESQL_PORT"
+export DB_PATH="$POSTGRESQL_PATH"
+export DB_DATABASE="$DB_PATH"
+export DB_USERNAME="$POSTGRESQL_USERNAME"
+export DB_PASSWORD="$POSTGRESQL_PASSWORD"
+export DB_SCHEME="postgresql"
+export DATABASE_URL="${DB_SCHEME}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_PATH}?sslmode=disable"
+
+# Set email service environment variables
+export EMAIL_NOREPLY="noreply@platform.sh"
+if [ "$PLATFORM_ENVIRONMENT_TYPE" != "production" ]; then
+  export EMAIL_SMTP_HOST="only_available_in_prod"
+else
+  export EMAIL_SMTP_HOST="${PLATFORM_SMTP_HOST}"
+fi
+export EMAIL_SMTP_PORT="25"
+
+# Set general environment specifics
+export BASE_URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key')
+export GO_ENV="${PLATFORM_ENVIRONMENT_TYPE}"
+export JWT_SECRET=$PLATFORM_PROJECT_ENTROPY

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -1,0 +1,80 @@
+# Defines and version-controls your hosting infrastructure on Upsun.com
+# applications: defines applications within this repository to deploy.
+---
+applications:
+  fider-application:
+    source:
+      root: "/"
+
+    type: "golang:1.22"
+
+    relationships:
+      postgresql:
+        # service: the service ("postgresql") defined in .upsun/services.yaml
+        service: postgresql
+        endpoint: admin
+    
+    web:
+      commands:
+        start: ./fider
+      upstream:
+        socket_family: tcp
+      locations:
+        "/":
+          passthru: true
+
+    timezone: "Europe/Paris"
+
+    variables:
+      env:
+        N_PREFIX: "/app/.global"
+
+    build:
+      flavor: none
+
+    dependencies:
+      nodejs:
+        n: "*"
+        npx: "*"
+
+    hooks:
+      build: |
+        set -eux
+        n auto || n lts
+        hash -r
+        npm i
+        go build
+        npm run  heroku-postbuild
+
+      deploy: |
+        set -eux
+        ./fider migrate
+
+
+# Defines and version-controls your services requirements
+# services: services can be databases, cache, storage and more
+services:
+  # postgressql: Can be changed to any string value.
+  #    Renaming must be reflected in `applications.{app-name}.relationships`
+  postgresql:
+    type: postgresql:15
+    configuration:
+      databases:
+        - fider
+      endpoints:
+        admin:
+          default_database: fider
+          privileges:
+            fider: admin
+
+
+# Defines and version-controls the routes required by the defined applications
+# routes: enables you to define hostname and path proxies
+routes:
+  "https://{default}/":
+    type: upstream
+    # upstream: Points our default domain to our application defined above.
+    upstream: "fider-application:http"
+  "https://www.{default}":
+    type: redirect
+    to: "https://{default}/"


### PR DESCRIPTION
**Issue:** #1228

Add's version-controlled infrastructure to the Fider repository to enable developers exploring Fider to deploy to Upsun in a few short steps without needing to worry about docker.


Relevant documentation MR: https://github.com/getfider/fider-docs/pull/2