### PR TITLE
Redirect Vuln in signout link

### DIFF
--- a/app/handlers/oauth_test.go
+++ b/app/handlers/oauth_test.go
@@ -31,7 +31,7 @@ func TestSignOutHandler(t *testing.T) {
 
 	server := mock.NewServer()
 	code, response := server.
-		WithURL("http://demo.test.fider.io/signout?redirect=/").
+		WithURL("http://demo.test.fider.io/signout").
 		AddCookie(web.CookieAuthName, "some-value").
 		Execute(handlers.SignOut())
 

--- a/app/handlers/signin.go
+++ b/app/handlers/signin.go
@@ -152,6 +152,6 @@ func CompleteSignInProfile() web.HandlerFunc {
 func SignOut() web.HandlerFunc {
 	return func(c *web.Context) error {
 		c.RemoveCookie(web.CookieAuthName)
-		return c.Redirect(c.QueryParam("redirect"))
+		return c.Redirect("/")
 	}
 }

--- a/e2e/step_definitions/user.steps.ts
+++ b/e2e/step_definitions/user.steps.ts
@@ -9,7 +9,7 @@ Given("I sign in as {string}", async function (this: FiderWorld, userName: strin
 
   if (await isAuthenticated(this.page)) {
     await this.page.click(".c-menu-user .c-dropdown__handle")
-    await this.page.click("a[href='/signout?redirect=/']")
+    await this.page.click("a[href='/signout']")
   }
 
   const userEmail = `${userName}-${this.tenantName}@fider.io`

--- a/public/components/UserMenu.tsx
+++ b/public/components/UserMenu.tsx
@@ -26,7 +26,7 @@ export const UserMenu = () => {
             <Dropdown.Divider />
           </>
         )}
-        <Dropdown.ListItem href="/signout?redirect=/">
+        <Dropdown.ListItem href="/signout">
           <Trans id="menu.signout">Sign out</Trans>
         </Dropdown.ListItem>
       </Dropdown>


### PR DESCRIPTION
There is a redirect vuln in the signout URL, this PR fixes that by removed the support for the redirect.