### PR TITLE
Sourcing the fonts from the inter NPM package

### DIFF
--- a/app/middlewares/security_test.go
+++ b/app/middlewares/security_test.go
@@ -23,7 +23,7 @@ func TestSecureWithoutCDN(t *testing.T) {
 		return c.NoContent(http.StatusOK)
 	})
 
-	expectedPolicy := "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paddle.com ; script-src 'self' 'nonce-" + ctxID + "' https://www.google-analytics.com https://*.paddle.com ; img-src 'self' https: data: ; font-src 'self' https://fonts.gstatic.com data: ; object-src 'none'; media-src 'none'; connect-src 'self' https://www.google-analytics.com ; frame-src 'self' https://*.paddle.com"
+	expectedPolicy := "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' https://*.paddle.com ; script-src 'self' 'nonce-" + ctxID + "' https://www.google-analytics.com https://*.paddle.com ; img-src 'self' https: data: ; font-src 'self' data: ; object-src 'none'; media-src 'none'; connect-src 'self' https://www.google-analytics.com ; frame-src 'self' https://*.paddle.com"
 
 	Expect(status).Equals(http.StatusOK)
 	Expect(response.Header().Get("Content-Security-Policy")).Equals(expectedPolicy)
@@ -46,7 +46,7 @@ func TestSecureWithCDN(t *testing.T) {
 		return c.NoContent(http.StatusOK)
 	})
 
-	expectedPolicy := "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paddle.com *.test.fider.io; script-src 'self' 'nonce-" + ctxID + "' https://www.google-analytics.com https://*.paddle.com *.test.fider.io; img-src 'self' https: data: *.test.fider.io; font-src 'self' https://fonts.gstatic.com data: *.test.fider.io; object-src 'none'; media-src 'none'; connect-src 'self' https://www.google-analytics.com *.test.fider.io; frame-src 'self' https://*.paddle.com"
+	expectedPolicy := "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' https://*.paddle.com *.test.fider.io; script-src 'self' 'nonce-" + ctxID + "' https://www.google-analytics.com https://*.paddle.com *.test.fider.io; img-src 'self' https: data: *.test.fider.io; font-src 'self' data: *.test.fider.io; object-src 'none'; media-src 'none'; connect-src 'self' https://www.google-analytics.com *.test.fider.io; frame-src 'self' https://*.paddle.com"
 
 	Expect(status).Equals(http.StatusOK)
 	Expect(response.Header().Get("Content-Security-Policy")).Equals(expectedPolicy)
@@ -69,7 +69,7 @@ func TestSecureWithCDN_SingleHost(t *testing.T) {
 		return c.NoContent(http.StatusOK)
 	})
 
-	expectedPolicy := "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paddle.com test.fider.io; script-src 'self' 'nonce-" + ctxID + "' https://www.google-analytics.com https://*.paddle.com test.fider.io; img-src 'self' https: data: test.fider.io; font-src 'self' https://fonts.gstatic.com data: test.fider.io; object-src 'none'; media-src 'none'; connect-src 'self' https://www.google-analytics.com test.fider.io; frame-src 'self' https://*.paddle.com"
+	expectedPolicy := "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' https://*.paddle.com test.fider.io; script-src 'self' 'nonce-" + ctxID + "' https://www.google-analytics.com https://*.paddle.com test.fider.io; img-src 'self' https: data: test.fider.io; font-src 'self' data: test.fider.io; object-src 'none'; media-src 'none'; connect-src 'self' https://www.google-analytics.com test.fider.io; frame-src 'self' https://*.paddle.com"
 
 	Expect(status).Equals(http.StatusOK)
 	Expect(response.Header().Get("Content-Security-Policy")).Equals(expectedPolicy)

--- a/app/pkg/web/engine.go
+++ b/app/pkg/web/engine.go
@@ -22,15 +22,14 @@ import (
 	cache "github.com/patrickmn/go-cache"
 )
 
-// fonts.gstatic.com and fonts.googleapis.com are required for Custom CSS to work with Google Fonts
 // unsafe-inline on Style is required for rendering Tags on SSR
 
 var (
 	cspBase    = "base-uri 'self'"
 	cspDefault = "default-src 'self'"
-	cspStyle   = "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.paddle.com %[2]s"
+	cspStyle   = "style-src 'self' 'unsafe-inline' https://*.paddle.com %[2]s"
 	cspScript  = "script-src 'self' 'nonce-%[1]s' https://www.google-analytics.com https://*.paddle.com %[2]s"
-	cspFont    = "font-src 'self' https://fonts.gstatic.com data: %[2]s"
+	cspFont    = "font-src 'self' data: %[2]s"
 	cspImage   = "img-src 'self' https: data: %[2]s"
 	cspObject  = "object-src 'none'"
 	cspFrame   = "frame-src 'self' https://*.paddle.com"

--- a/app/pkg/web/testdata/basic.html
+++ b/app/pkg/web/testdata/basic.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/app/pkg/web/testdata/canonical.html
+++ b/app/pkg/web/testdata/canonical.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
     <link rel="canonical" href="http://feedback.demo.org" />
   

--- a/app/pkg/web/testdata/chunk.html
+++ b/app/pkg/web/testdata/chunk.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/app/pkg/web/testdata/home.html
+++ b/app/pkg/web/testdata/home.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/app/pkg/web/testdata/home_ssr.html
+++ b/app/pkg/web/testdata/home_ssr.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/app/pkg/web/testdata/oauth.html
+++ b/app/pkg/web/testdata/oauth.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/app/pkg/web/testdata/tenant.html
+++ b/app/pkg/web/testdata/tenant.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/app/pkg/web/testdata/user.html
+++ b/app/pkg/web/testdata/user.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="https://demo.test.fider.io:3000/static/favicon?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="https://demo.test.fider.io:3000/static/favicon?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   
   
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/starter-kit": "^2.11.5",
         "@tiptap/suggestion": "^2.11.5",
         "dompurify": "^3.2.4",
+        "inter-ui": "^4.1.0",
         "marked": "^4.0.15",
         "prosemirror-markdown": "^1.13.1",
         "react": "^18.3.1",
@@ -10495,6 +10496,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inter-ui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/inter-ui/-/inter-ui-4.1.0.tgz",
+      "integrity": "sha512-lUJ5YLtpj7jWsrhTbN5w32MLOqISGFGOTMRNn+IGhLrbt67z5yvmBRoqpLCWLVlJ+l7kqnH6su4meEqvLMfAAA==",
+      "license": "OFL-1.1",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/internal-slot": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tiptap/starter-kit": "^2.11.5",
     "@tiptap/suggestion": "^2.11.5",
     "dompurify": "^3.2.4",
+    "inter-ui": "^4.1.0",
     "marked": "^4.0.15",
     "prosemirror-markdown": "^1.13.1",
     "react": "^18.3.1",

--- a/public/assets/styles/variables.scss
+++ b/public/assets/styles/variables.scss
@@ -1,8 +1,21 @@
+@use "~inter-ui/default" with (
+  $inter-font-display: swap,
+  $inter-font-path: "~inter-ui/web"
+);
+
+@use "~inter-ui/variable" with (
+  $inter-font-display: swap,
+  $inter-font-path: "~inter-ui/variable"
+);
+
 @import "variables/_functions";
 @import "variables/_colors";
 @import "variables/_spacing";
 @import "variables/_sizing";
 @import "variables/_text";
+
+@include default.all;
+@include variable.all;
 
 $all: (
   colors: $colors,

--- a/views/base.html
+++ b/views/base.html
@@ -6,9 +6,6 @@
   <link rel="icon" href="{{ .private.favicon }}?size=64" sizes="64x64" type="image/png">
   <link rel="icon" href="{{ .private.favicon }}?size=192" sizes="192x192" type="image/png">
   <link rel="apple-touch-icon" href="{{ .private.favicon }}?size=180&bg=white" sizes="180x180" type="image/png">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
   {{ if .private.canonicalURL }}
     <link rel="canonical" href="{{ .private.canonicalURL }}" />
   {{ end }}


### PR DESCRIPTION
This is an alternative solution for packaging up the Inter font with the app, rather than dubious GDPR issues linking it from google directly.

Fixes #1279 