### PR TITLE
Build version update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   release:
-    types: [created]
+    types: [published]
   push:
     branches:
       - main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,9 @@ jobs:
         with:
           push: true
           context: .
-          build-args: COMMITHASH=${{ github.event.workflow_run.head_sha }}
+          build-args: |
+            COMMITHASH=${{ github.event.workflow_run.head_sha }}
+            VERSION=${{ github.event.workflow_run.display_title }}
           platforms: linux/amd64,linux/arm64/v8
           tags: getfider/fider:${{ github.event.workflow_run.display_title }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN go mod download
 COPY . ./
 
 ARG COMMITHASH
-RUN COMMITHASH=${COMMITHASH} GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-server
+ARG VERSION
+RUN COMMITHASH=${COMMITHASH} VERSION=${VERSION} GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-server
 #################
 ### UI Build Step
 #################

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 ## For more information, refer to https://www.thapaliya.com/en/writings/well-documented-makefiles/
 
 LDFLAGS += -X github.com/getfider/fider/app/pkg/env.commithash=${COMMITHASH}
+LDFLAGS += -X github.com/getfider/fider/app/pkg/env.version=${VERSION}
 
 
 

--- a/app/pkg/env/env.go
+++ b/app/pkg/env/env.go
@@ -16,17 +16,22 @@ import (
 )
 
 var (
-	// this value is set by the CI build
+	// these values are set by the CI build
 	commithash = ""
-	version    = "0.22.0"
+	version    = ""
 )
 
 func Version() string {
-	if commithash == "" {
-		return fmt.Sprintf("%s-dev", version)
+	v := version
+	if v == "" {
+		v = "dev"
 	}
 
-	return fmt.Sprintf("%s-%s", version, commithash)
+	if commithash == "" {
+		return v
+	}
+
+	return fmt.Sprintf("%s-%s", v, commithash)
 }
 
 type config struct {
@@ -49,7 +54,7 @@ type config struct {
 	Locale                      string `env:"LOCALE,default=en"`
 	JWTSecret                   string `env:"JWT_SECRET,required"`
 	PostCreationWithTagsEnabled bool   `env:"POST_CREATION_WITH_TAGS_ENABLED,default=false"`
-	Paddle     struct {
+	Paddle                      struct {
 		IsSandbox      bool   `env:"PADDLE_SANDBOX,default=false"`
 		VendorID       string `env:"PADDLE_VENDOR_ID"`
 		VendorAuthCode string `env:"PADDLE_VENDOR_AUTHCODE"`


### PR DESCRIPTION
Potential fix / improvement for #1300 

This should update the version string from the build process, by using the github tag when you create a release, and passing that into the docker build.