### PR TITLE
Improved redirect handling on oauth signin page (#1321)

### DIFF
--- a/public/pages/SignIn/SignIn.page.tsx
+++ b/public/pages/SignIn/SignIn.page.tsx
@@ -52,7 +52,13 @@ export const SignInPage = () => {
       </div>
       <div className="text-center w-max-4xl mx-auto mb-4">{fider.session.tenant.isPrivate ? <Private /> : <Locked />}</div>
 
-      <SignInControl onEmailSent={onEmailSent} useEmail={true} redirectTo={fider.settings.baseURL} />
+      <SignInControl
+        onEmailSent={onEmailSent}
+        useEmail={true}
+        redirectTo={
+          typeof window !== "undefined" ? new URLSearchParams(window.location.search).get("redirect") || fider.settings.baseURL : fider.settings.baseURL
+        }
+      />
       <LegalNotice />
     </div>
   )


### PR DESCRIPTION
I am not sure if this is a good way to solve this issue. 

I noticed, that the tenant.go file redirects the user to the signin page and removes all path and query parts. So I added the Requested URI to a redirect query part and look for that in the frontend. 

This causes the url to be a bit bloated. Maybe the redirect url could be put in the redirect body, so the url stays pretty? But that would be over my golang skill.