### PR TITLE
Improved handling of long strings in titles and code blocks (#1333)

### DIFF
--- a/app/services/email/email_test.go
+++ b/app/services/email/email_test.go
@@ -23,6 +23,25 @@ func TestRenderMessage(t *testing.T) {
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="viewport" content="width=device-width">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<style>
+			.user-content {
+				text-align: left;
+				padding: 20px;
+				margin: 10px;
+				border-radius: 5px;
+				color: #1c262d;
+				border: 1px solid #ECECEC;
+				min-width: 320px;
+				max-width: 660px;
+				overflow-wrap: break-word;
+				word-break: break-word;
+				table-layout: fixed;
+
+				pre:has(code) {
+					white-space: break-spaces;
+				}
+			}
+		</style>
 	</head>
 	<body bgcolor="#F7F7F7" style="font-size:18px">
 		<table width="100%" bgcolor="#F7F7F7" cellpadding="0" cellspacing="0" border="0" style="text-align:center;font-size:18px;">
@@ -32,7 +51,7 @@ func TestRenderMessage(t *testing.T) {
 			
 			<tr>
 				<td align="center">
-					<table bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0" style="text-align:left;padding:20px;margin:10px;border-radius:5px;color:#1c262d;border:1px solid #ECECEC;min-width:320px;max-width:660px;">
+					<table class="user-content" bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0">
 						
 Hello World Fider!
 

--- a/app/services/email/mailgun/sendmail_test.go
+++ b/app/services/email/mailgun/sendmail_test.go
@@ -70,6 +70,25 @@ func TestSend_Success(t *testing.T) {
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="viewport" content="width=device-width">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<style>
+			.user-content {
+				text-align: left;
+				padding: 20px;
+				margin: 10px;
+				border-radius: 5px;
+				color: #1c262d;
+				border: 1px solid #ECECEC;
+				min-width: 320px;
+				max-width: 660px;
+				overflow-wrap: break-word;
+				word-break: break-word;
+				table-layout: fixed;
+
+				pre:has(code) {
+					white-space: break-spaces;
+				}
+			}
+		</style>
 	</head>
 	<body bgcolor="#F7F7F7" style="font-size:18px">
 		<table width="100%" bgcolor="#F7F7F7" cellpadding="0" cellspacing="0" border="0" style="text-align:center;font-size:18px;">
@@ -79,7 +98,7 @@ func TestSend_Success(t *testing.T) {
 			
 			<tr>
 				<td align="center">
-					<table bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0" style="text-align:left;padding:20px;margin:10px;border-radius:5px;color:#1c262d;border:1px solid #ECECEC;min-width:320px;max-width:660px;">
+					<table class="user-content" bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0">
 						
 Hello World Hello!
 
@@ -196,6 +215,25 @@ func TestBatch_Success(t *testing.T) {
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="viewport" content="width=device-width">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<style>
+			.user-content {
+				text-align: left;
+				padding: 20px;
+				margin: 10px;
+				border-radius: 5px;
+				color: #1c262d;
+				border: 1px solid #ECECEC;
+				min-width: 320px;
+				max-width: 660px;
+				overflow-wrap: break-word;
+				word-break: break-word;
+				table-layout: fixed;
+
+				pre:has(code) {
+					white-space: break-spaces;
+				}
+			}
+		</style>
 	</head>
 	<body bgcolor="#F7F7F7" style="font-size:18px">
 		<table width="100%" bgcolor="#F7F7F7" cellpadding="0" cellspacing="0" border="0" style="text-align:center;font-size:18px;">
@@ -205,7 +243,7 @@ func TestBatch_Success(t *testing.T) {
 			
 			<tr>
 				<td align="center">
-					<table bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0" style="text-align:left;padding:20px;margin:10px;border-radius:5px;color:#1c262d;border:1px solid #ECECEC;min-width:320px;max-width:660px;">
+					<table class="user-content" bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0">
 						
 Hello World %recipient.name%!
 

--- a/public/assets/styles/utility/text.scss
+++ b/public/assets/styles/utility/text.scss
@@ -132,3 +132,8 @@ pre:last-child {
 .uppercase {
   text-transform: uppercase;
 }
+
+.text-break {
+  word-break: break-all;
+  overflow-wrap: break-word;
+}

--- a/public/assets/styles/variables/_sizing.scss
+++ b/public/assets/styles/variables/_sizing.scss
@@ -1,5 +1,5 @@
-$spacing-inc: 4px;
+$sizing-inc: 4px;
 
-@function spacing($i) {
-  @return $spacing-inc * $i;
+@function sizing($i) {
+  @return $sizing-inc * $i;
 }

--- a/public/assets/styles/variables/_spacing.scss
+++ b/public/assets/styles/variables/_spacing.scss
@@ -1,5 +1,5 @@
-$sizing-inc: 4px;
+$spacing-inc: 4px;
 
-@function sizing($i) {
-  @return $sizing-inc * $i;
+@function spacing($i) {
+  @return $spacing-inc * $i;
 }

--- a/public/components/common/Dropdown.scss
+++ b/public/components/common/Dropdown.scss
@@ -12,6 +12,7 @@
     padding: 0;
     cursor: pointer;
     color: var(--colors-black);
+    display: flex;
   }
 
   &__list {

--- a/public/components/common/Markdown.scss
+++ b/public/components/common/Markdown.scss
@@ -43,17 +43,16 @@
   }
 
   pre {
-    overflow-x: auto;
+    overflow-x: scroll;
     padding: spacing(2);
     line-height: 1.45;
     background-color: var(--colors-gray-200);
     border-radius: 4px;
+
     code {
       display: inline;
-      max-width: auto;
       padding: 0;
       margin: 0;
-      overflow: visible;
       line-height: inherit;
       word-wrap: normal;
       // background-color: transparent;

--- a/public/components/common/Markdown.scss
+++ b/public/components/common/Markdown.scss
@@ -43,7 +43,7 @@
   }
 
   pre {
-    overflow-x: scroll;
+    overflow-x: auto;
     padding: spacing(2);
     line-height: 1.45;
     background-color: var(--colors-gray-200);

--- a/public/pages/Home/components/ListPosts.tsx
+++ b/public/pages/Home/components/ListPosts.tsx
@@ -23,7 +23,7 @@ const ListPostItem = (props: { post: Post; user?: CurrentUser; tags: Tag[] }) =>
           </div>
         )}
         <HStack justify="between">
-          <a className="text-title hover:text-primary-base" href={`/posts/${props.post.number}/${props.post.slug}`}>
+          <a className="text-title text-break hover:text-primary-base" href={`/posts/${props.post.number}/${props.post.slug}`}>
             {props.post.title}
           </a>
           {props.post.commentsCount > 0 && (

--- a/public/pages/ShowPost/ShowPost.page.scss
+++ b/public/pages/ShowPost/ShowPost.page.scss
@@ -34,6 +34,7 @@
 
       &__main-col {
         grid-area: Main;
+        overflow: auto;
       }
 
       &__action-col {

--- a/public/pages/ShowPost/ShowPost.page.tsx
+++ b/public/pages/ShowPost/ShowPost.page.tsx
@@ -203,7 +203,7 @@ export default function ShowPostPage(props: ShowPostPageProps) {
                     </Form>
                   ) : (
                     <>
-                      <h1 className="text-large">{props.post.title}</h1>
+                      <h1 className="text-large text-break">{props.post.title}</h1>
                     </>
                   )}
                 </div>

--- a/public/pages/ShowPost/components/ShowComment.scss
+++ b/public/pages/ShowPost/components/ShowComment.scss
@@ -1,0 +1,6 @@
+@use "~@fider/assets/styles/variables.scss" as *;
+
+.comment-area {
+    // spacing(8) for the avatar + spacing(1) for padding right
+    width: calc(100% - spacing(9));
+}

--- a/public/pages/ShowPost/components/ShowComment.tsx
+++ b/public/pages/ShowPost/components/ShowComment.tsx
@@ -9,6 +9,8 @@ import { t } from "@lingui/core/macro"
 import { Trans } from "@lingui/react/macro"
 import CommentEditor from "@fider/components/common/form/CommentEditor"
 
+import "./ShowComment.scss"
+
 interface ShowCommentProps {
   post: Post
   comment: Comment
@@ -153,7 +155,7 @@ export const ShowComment = (props: ShowCommentProps) => {
   )
 
   const classList = classSet({
-    "flex-grow rounded-md p-2": true,
+    "flex-grow rounded-md p-2 comment-area": true,
     "bg-gray-100": !props.highlighted,
     "bg-gray-200": props.highlighted,
   })

--- a/views/email/base_email.html
+++ b/views/email/base_email.html
@@ -6,6 +6,25 @@ body:
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="viewport" content="width=device-width">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<style>
+			.user-content {
+				text-align: left;
+				padding: 20px;
+				margin: 10px;
+				border-radius: 5px;
+				color: #1c262d;
+				border: 1px solid #ECECEC;
+				min-width: 320px;
+				max-width: 660px;
+				overflow-wrap: break-word;
+				word-break: break-word;
+				table-layout: fixed;
+
+				pre:has(code) {
+					white-space: break-spaces;
+				}
+			}
+		</style>
 	</head>
 	<body bgcolor="#F7F7F7" style="font-size:18px">
 		<table width="100%" bgcolor="#F7F7F7" cellpadding="0" cellspacing="0" border="0" style="text-align:center;font-size:18px;">
@@ -24,7 +43,7 @@ body:
 			{{ end }}
 			<tr>
 				<td align="center">
-					<table bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0" style="text-align:left;padding:20px;margin:10px;border-radius:5px;color:#1c262d;border:1px solid #ECECEC;min-width:320px;max-width:660px;">
+					<table class="user-content" bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" border="0">
 						{{block "body" .}}{{end}}
 					</table>
 				</td>


### PR DESCRIPTION
**Issue:** https://github.com/getfider/fider/issues/1333

- I added a word-break class to allow easy breaking of long titles etc.
- I noticed that the spacing and sizing scss files where wrongly named and fixed that.
- Code blocks now have scrolling to prevent horizontal page scrolling.
- Comments have a calculated max width to prevent breaking the layout.

Also added:
- Better line breaking in mails
