### PR TITLE
Share feedback fixes

### DIFF
--- a/app/actions/signin.go
+++ b/app/actions/signin.go
@@ -15,7 +15,6 @@ import (
 // SignInByEmail happens when user request to sign in by email
 type SignInByEmail struct {
 	Email           string `json:"email" format:"lower"`
-	Code            string `json:"code"`
 	VerificationKey string
 }
 

--- a/app/handlers/signin.go
+++ b/app/handlers/signin.go
@@ -74,7 +74,7 @@ func SignInByEmail() web.HandlerFunc {
 			return c.Failure(err)
 		}
 
-		c.Enqueue(tasks.SendSignInEmail(action.Email, action.Code, action.VerificationKey))
+		c.Enqueue(tasks.SendSignInEmail(action.Email, action.VerificationKey))
 
 		return c.Ok(web.Map{})
 	}
@@ -103,7 +103,6 @@ func VerifySignInKey(kind enum.EmailVerificationKind) web.HandlerFunc {
 					Data: web.Map{
 						"kind": kind,
 						"k":    key,
-						"c":    c.QueryParam("c"),
 					},
 				})
 			}
@@ -118,9 +117,6 @@ func VerifySignInKey(kind enum.EmailVerificationKind) web.HandlerFunc {
 		webutil.AddAuthUserCookie(c, userByEmail.Result)
 
 		baseURL := c.BaseURL()
-		if codeQs := c.QueryParam("c"); codeQs != "" {
-			return c.Redirect(baseURL + "?c=" + codeQs)
-		}
 		return c.Redirect(baseURL)
 	}
 }

--- a/app/tasks/signin.go
+++ b/app/tasks/signin.go
@@ -9,11 +9,11 @@ import (
 )
 
 // SendSignInEmail is used to send the sign in email to requestor
-func SendSignInEmail(email, code, verificationKey string) worker.Task {
+func SendSignInEmail(email, verificationKey string) worker.Task {
 	return describe("Send sign in email", func(c *worker.Context) error {
 		to := dto.NewRecipient("", email, dto.Props{
 			"siteName": c.Tenant().Name,
-			"link":     link(web.BaseURL(c), "/signin/verify?k=%s&c=%s", verificationKey, code),
+			"link":     link(web.BaseURL(c), "/signin/verify?k=%s", verificationKey),
 		})
 
 		bus.Publish(c, &cmd.SendMail{

--- a/app/tasks/signin_test.go
+++ b/app/tasks/signin_test.go
@@ -16,7 +16,7 @@ func TestSendSignInEmailTask(t *testing.T) {
 	bus.Init(emailmock.Service{})
 
 	worker := mock.NewWorker()
-	task := tasks.SendSignInEmail("jon@got.com", "9876", "9876")
+	task := tasks.SendSignInEmail("jon@got.com", "9876")
 
 	err := worker.
 		OnTenant(mock.DemoTenant).
@@ -39,7 +39,7 @@ func TestSendSignInEmailTask(t *testing.T) {
 		Address: "jon@got.com",
 		Props: dto.Props{
 			"siteName": mock.DemoTenant.Name,
-			"link":     "<a href='http://domain.com/signin/verify?k=9876&c=9876'>http://domain.com/signin/verify?k=9876&c=9876</a>",
+			"link":     "<a href='http://domain.com/signin/verify?k=9876'>http://domain.com/signin/verify?k=9876</a>",
 		},
 	})
 }

--- a/public/pages/Home/Home.page.tsx
+++ b/public/pages/Home/Home.page.tsx
@@ -1,7 +1,7 @@
 import "./Home.page.scss"
 import NoDataIllustration from "@fider/assets/images/undraw-no-data.svg"
 
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Post, Tag, PostStatus } from "@fider/models"
 import { Markdown, Hint, PoweredByFider, Icon, Header, Button } from "@fider/components"
 import { PostsContainer } from "./components/PostsContainer"
@@ -10,7 +10,7 @@ import { VStack } from "@fider/components/layout"
 import { ShareFeedback } from "./components/ShareFeedback"
 import { i18n } from "@lingui/core"
 import { Trans } from "@lingui/react/macro"
-import { isPostPending } from "./components/PostCache"
+import { isPostPending, setPostPending } from "./components/PostCache"
 
 export interface HomePageProps {
   posts: Post[]
@@ -48,6 +48,15 @@ const HomePage = (props: HomePageProps) => {
   const fider = useFider()
   // const [title, setTitle] = useState("")
   const [isShareFeedbackOpen, setIsShareFeedbackOpen] = useState(isPostPending())
+
+  useEffect(() => {
+    // If we're showing the share feedback, make sure we clear the show pending flag (for draft posts)
+    if (isShareFeedbackOpen) {
+      if (isPostPending()) {
+        setPostPending(false)
+      }
+    }
+  })
 
   const defaultWelcomeMessage = i18n._({
     id: "home.form.defaultwelcomemessage",

--- a/public/pages/Home/Home.page.tsx
+++ b/public/pages/Home/Home.page.tsx
@@ -89,7 +89,7 @@ What can we do better? This is the place for you to vote, discuss and share idea
       <ShareFeedback
         tags={props.tags}
         placeholder={fider.session.tenant.invitation || defaultInvitation}
-        isOpen={isShareFeedbackOpen}
+        isOpen={isShareFeedbackOpen && !fider.isReadOnly}
         onClose={() => setIsShareFeedbackOpen(false)}
       />
       <Header />

--- a/public/pages/Home/components/ShareFeedback.tsx
+++ b/public/pages/Home/components/ShareFeedback.tsx
@@ -220,7 +220,7 @@ export const ShareFeedback: React.FC<ShareFeedbackProps> = (props) => {
                   onChange={handleDescriptionChange}
                   onFocus={handleEditorFocus}
                   initialValue={description}
-                  disabled={false}
+                  disabled={fider.isReadOnly}
                   maxAttachments={3}
                   maxImageSizeKB={5 * 1024}
                   placeholder={i18n._({
@@ -238,6 +238,7 @@ export const ShareFeedback: React.FC<ShareFeedbackProps> = (props) => {
                 maxLength={255}
                 label={i18n._({ id: "newpost.modal.title.label", message: "Give your idea a title" })}
                 value={title}
+                disabled={fider.isReadOnly}
                 onChange={handleTitleChange}
                 placeholder={i18n._({ id: "newpost.modal.title.placeholder", message: "Something short and snappy, sum it up in a few words" })}
               />


### PR DESCRIPTION
Fixes a few issues with the new share feedback page:

- Form reappears if you cancel from a new signup
- Readonly sites were still allowing the form to enter a new post to be completed