### PR TITLE
France translation error and improved idea title behaviour

### DIFF
--- a/locale/fr/client.json
+++ b/locale/fr/client.json
@@ -38,7 +38,7 @@
   "error.pagenotfound.title": "Page non trouvée",
   "error.unauthorized.text": "Vous n'êtes pas autorisé à accéder à cette page.",
   "error.unauthorized.title": "Non autorisé",
-  "home.filter.label": "Flitrer",
+  "home.filter.label": "Filtrer",
   "home.filter.search.label": "Rechercher dans les filtres...",
   "home.form.defaultinvitation": "Entrez votre suggestion ici...",
   "home.form.defaultwelcomemessage": "Nous aimerions savoir ce que vous pensez.\n\nQue pouvons-nous faire de mieux ? C'est ici que vous pouvez voter, discuter et partager vos idées.",

--- a/public/pages/Home/components/ShareFeedback.tsx
+++ b/public/pages/Home/components/ShareFeedback.tsx
@@ -139,8 +139,9 @@ export const ShareFeedback: React.FC<ShareFeedbackProps> = (props) => {
     setCachedTitle(value)
     // If this is a manual edit (not auto-generated from description),
     // mark the title as manually edited so we stop auto-populating
+    // If the user clears the title, we still want to allow auto-population
     if (isManualEdit) {
-      setTitleManuallyEdited(true)
+      setTitleManuallyEdited(value !== "")
     }
   }
 
@@ -157,6 +158,12 @@ export const ShareFeedback: React.FC<ShareFeedbackProps> = (props) => {
 
   const handleDescriptionChange = (value: string, plainText?: string) => {
     setCachedDescription(value)
+
+    // If the description starts with an image attachment, we don't want to set it as the title
+    if (value.startsWith("![](fider-image:attachments")) {
+      return
+    }
+
     setDescription(value)
 
     // Store plain text version if provided


### PR DESCRIPTION
I saw this issue on the fider feedback page and noticed that uploading a picture as the first element will set the markdown for the image as a title.
I also fixed the translation typo that this issue was made for.

**Issue:** https://feedback.fider.io/posts/580/fider-image-attachments-yz2wdhy0c7cxfjrshihgyvszjjp33efu1xp4cbtmma8osfic603p

What I changed:
- "Filter" translation in FR
- images will no longer set the title of an idea
- manually clearing the title will reset the "manually edited" flag
