### PR TITLE
fix: encode email subject headers according to RFC 2047

### DIFF
--- a/app/services/email/awsses/awsses.go
+++ b/app/services/email/awsses/awsses.go
@@ -110,7 +110,7 @@ func sendMail(ctx context.Context, c *cmd.SendMail) {
 					},
 					Subject: &ses.Content{
 						Charset: aws.String("UTF-8"),
-						Data:    aws.String(message.Subject),
+						Data:    aws.String(email.EncodeSubject(message.Subject)),
 					},
 				},
 			},

--- a/app/services/email/mailgun/sendmail.go
+++ b/app/services/email/mailgun/sendmail.go
@@ -50,7 +50,7 @@ func sendMail(ctx context.Context, c *cmd.SendMail) {
 	form := url.Values{}
 	form.Add("from", c.From.String())
 	form.Add("h:Reply-To", c.From.Address)
-	form.Add("subject", message.Subject)
+	form.Add("subject", email.EncodeSubject(message.Subject))
 	form.Add("html", message.Body)
 	form.Add("o:tag", fmt.Sprintf("template:%s", c.TemplateName))
 

--- a/app/services/email/message.go
+++ b/app/services/email/message.go
@@ -3,7 +3,9 @@ package email
 import (
 	"bytes"
 	"context"
+	"mime"
 	"strings"
+	"unicode"
 
 	"github.com/getfider/fider/app/models/dto"
 	"github.com/getfider/fider/app/pkg/tpl"
@@ -13,6 +15,26 @@ import (
 type Message struct {
 	Subject string
 	Body    string
+}
+
+// EncodeSubject encodes the subject header according to RFC 2047 if it contains non-ASCII characters
+func EncodeSubject(subject string) string {
+	// Check if the subject contains non-ASCII characters
+	hasNonASCII := false
+	for _, r := range subject {
+		if r > unicode.MaxASCII {
+			hasNonASCII = true
+			break
+		}
+	}
+	
+	// If it's pure ASCII, no encoding is needed
+	if !hasNonASCII {
+		return subject
+	}
+	
+	// Use Go's built-in MIME header encoding which implements RFC 2047
+	return mime.QEncoding.Encode("utf-8", subject)
 }
 
 // RenderMessage returns the HTML of an email based on template and params

--- a/app/services/email/message_test.go
+++ b/app/services/email/message_test.go
@@ -1,0 +1,59 @@
+package email_test
+
+import (
+	"testing"
+
+	"github.com/getfider/fider/app/services/email"
+	. "github.com/getfider/fider/app/pkg/assert"
+)
+
+func TestEncodeSubject_ASCIIOnly(t *testing.T) {
+	RegisterT(t)
+	
+	subject := "Hello World"
+	encoded := email.EncodeSubject(subject)
+	
+	Expect(encoded).Equals("Hello World")
+}
+
+func TestEncodeSubject_WithNonASCII(t *testing.T) {
+	RegisterT(t)
+	
+	subject := "Test ä ö ü"
+	encoded := email.EncodeSubject(subject)
+	
+	// The encoded result should be in RFC 2047 format
+	Expect(encoded).ContainsSubstring("=?utf-8?q?")
+	Expect(encoded).ContainsSubstring("?=")
+}
+
+func TestEncodeSubject_WithEmoji(t *testing.T) {
+	RegisterT(t)
+	
+	subject := "Hello 👋 World 🌍"
+	encoded := email.EncodeSubject(subject)
+	
+	// The encoded result should be in RFC 2047 format
+	Expect(encoded).ContainsSubstring("=?utf-8?q?")
+	Expect(encoded).ContainsSubstring("?=")
+}
+
+func TestEncodeSubject_Empty(t *testing.T) {
+	RegisterT(t)
+	
+	subject := ""
+	encoded := email.EncodeSubject(subject)
+	
+	Expect(encoded).Equals("")
+}
+
+func TestEncodeSubject_WithUmlautsAndSpecialChars(t *testing.T) {
+	RegisterT(t)
+	
+	subject := "Öffentliche Ankündigung - Größere Änderungen"
+	encoded := email.EncodeSubject(subject)
+	
+	// The encoded result should be in RFC 2047 format
+	Expect(encoded).ContainsSubstring("=?utf-8?q?")
+	Expect(encoded).ContainsSubstring("?=")
+}

--- a/app/services/email/smtp/smtp.go
+++ b/app/services/email/smtp/smtp.go
@@ -90,7 +90,7 @@ func sendMail(ctx context.Context, c *cmd.SendMail) {
 		b.Set("From", c.From.String())
 		b.Set("Reply-To", c.From.Address)
 		b.Set("To", to.String())
-		b.Set("Subject", message.Subject)
+		b.Set("Subject", email.EncodeSubject(message.Subject))
 		b.Set("MIME-version", "1.0")
 		b.Set("Content-Type", "text/html; charset=\"UTF-8\"")
 		b.Set("Date", time.Now().Format(time.RFC1123Z))


### PR DESCRIPTION
- Add EncodeSubject function to properly encode non-ASCII characters in email subject headers
- Use Go's built-in mime.QEncoding which implements RFC 2047 quoted-printable encoding
- Apply encoding in all email services: SMTP, Mailgun, and AWS SES
- ASCII-only subjects remain unencoded for compatibility
- Add comprehensive tests for the encoding function

This fixes issues with non-ASCII characters (umlauts, accents, emojis) in email subjects that were previously displayed incorrectly in some email clients and servers.

Resolves compatibility issues with downstream SMTP servers that don't support SMTPUTF8.

Fixes https://github.com/getfider/fider/issues/1147