### PR TITLE
fix(style): How long post titles break when wrapping

### DIFF
--- a/public/assets/styles/utility/text.scss
+++ b/public/assets/styles/utility/text.scss
@@ -134,6 +134,6 @@ pre:last-child {
 }
 
 .text-break {
-  word-break: break-all;
+  word-break: break-word;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
### Summary

**Issue:** #1368 

The CSS for the `.text-break` class would cause long post titles to break in the middle of a word when wrapping to the next line. This changes the default behavior to break around the word instead.

As far as I could tell this class was only referenced by the post title in the list page and the post page:

```
grep -Hnr "text-break" . --exclude-dir ./dist | cut -d: -f1,2
./public/assets/styles/utility/text.scss:136
./public/pages/Home/components/ListPosts.tsx:27
./public/pages/ShowPost/ShowPost.page.tsx:220
```

### Current behavior

<img width="384" height="277" alt="Screenshot 2025-10-02 at 4 35 24 PM" src="https://github.com/user-attachments/assets/18f34693-395a-4f3b-8670-45c223d0e1df" />

### New behavior

<img width="378" height="259" alt="Screenshot 2025-10-02 at 4 35 49 PM" src="https://github.com/user-attachments/assets/30f9f587-1a3b-437e-88bb-8ab454fe2167" />

