### PR TITLE
fix(ui): Link rendering in comment editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lingui/react": "^5.1.2",
         "@tiptap/extension-hard-break": "^2.11.5",
         "@tiptap/extension-image": "^2.22.3",
+        "@tiptap/extension-link": "^2.11.5",
         "@tiptap/extension-mention": "^2.11.5",
         "@tiptap/extension-placeholder": "^2.11.5",
         "@tiptap/pm": "^2.11.5",
@@ -4901,6 +4902,23 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.26.2.tgz",
+      "integrity": "sha512-rzYxx5wI1551ubPfW2pJ3V957cX/WAmbUI3q8Un+LlOsSmbddl+5BjlF5t/vl/pwaOv7FJAz9e29n877zkGOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
@@ -13642,6 +13660,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@lingui/react": "^5.1.2",
     "@tiptap/extension-hard-break": "^2.11.5",
     "@tiptap/extension-image": "^2.22.3",
+    "@tiptap/extension-link": "^2.11.5",
     "@tiptap/extension-mention": "^2.11.5",
     "@tiptap/extension-placeholder": "^2.11.5",
     "@tiptap/pm": "^2.11.5",

--- a/public/components/common/form/CommentEditor.tsx
+++ b/public/components/common/form/CommentEditor.tsx
@@ -1,5 +1,6 @@
 import { Editor } from "@tiptap/react"
 import StarterKit from "@tiptap/starter-kit"
+import Link from "@tiptap/extension-link"
 import React, { useState, useRef, useEffect } from "react"
 import { EditorContent, useEditor } from "@tiptap/react"
 import { Markdown } from "tiptap-markdown"
@@ -426,6 +427,16 @@ const Tiptap: React.FunctionComponent<CommentEditorProps> = (props) => {
       ]
     : [
         StarterKit,
+        Link.configure({
+          openOnClick: false,
+          autolink: true,
+          defaultProtocol: "https",
+          HTMLAttributes: {
+            class: "text-link",
+            target: "_blank",
+            rel: "noopener nofollow",
+          },
+        }),
         Markdown.configure({
           html: true,
           breaks: true,


### PR DESCRIPTION
### Summary

**Issue:** Fixes: #1370

Uses new npm dependency @tiptap/extension-link to fix link rendering. Previously links would be stripped from the editor in rich text mode. This extension allows users to:
- Insert links using markdown syntax in markdown mode
- Paste links directly in rich text mode
- Preserve links when toggling between modes

### Validation

Here's [a loom](https://www.loom.com/share/3d81a9e9b56e4f4590c470a36b7908bc?sid=57061e54-2e98-4baf-8f8f-568d973f6a79) explaining the current bug and highlighting the new fix

### Notes

- **Testing:** I didn't see an existing file for testing the `CommentEditor` component, but I might have missed it. I tried creating a new test file but wasn't having a little trouble hooking it into the existing test harness. If you want an accompanying unit test, I can spend bit more time on getting it to work!
- **Link menu button:** Now that links are working in rich text mode, it might be nice to add a link button to the `MenuBar` component, but I was trying to keep the surface area of this PR pretty small. If it would be helpful to add that link button I can try to tackle that in a separate enhancement PR.
- **Linking the issue:** I used the "Fixes" keyword to link this PR to the related issue. If you'd prefer to not have them linked directly I can edit the PR description.
