### PR TITLE
Allow setting listen addr with HOST and METRICS_HOST

### DIFF
--- a/app/cmd/server.go
+++ b/app/cmd/server.go
@@ -50,7 +50,7 @@ func RunServer() int {
 	startJobs(ctx)
 
 	e := routes(web.New())
-	go e.Start(":" + env.Config.Port)
+	go e.Start(env.Config.Host + ":" + env.Config.Port)
 	return listenSignals(e)
 }
 

--- a/app/pkg/env/env.go
+++ b/app/pkg/env/env.go
@@ -48,6 +48,7 @@ type config struct {
 		IdleTimeout  time.Duration `env:"HTTP_IDLE_TIMEOUT,default=120s,strict"`
 	}
 	Port                        string `env:"PORT,default=3000"`
+	Host                        string `env:"HOST,default="`
 	HostMode                    string `env:"HOST_MODE,default=single"`
 	HostDomain                  string `env:"HOST_DOMAIN"`
 	BaseURL                     string `env:"BASE_URL"`
@@ -66,6 +67,7 @@ type config struct {
 	Metrics struct {
 		Enabled bool   `env:"METRICS_ENABLED,default=false"`
 		Port    string `env:"METRICS_PORT,default=4000"`
+		Host    string `env:"METRICS_HOST,default="`
 	}
 	Database struct {
 		URL          string `env:"DATABASE_URL,required"`

--- a/app/pkg/web/engine.go
+++ b/app/pkg/web/engine.go
@@ -128,7 +128,7 @@ func (e *Engine) Start(address string) {
 	}
 
 	if env.Config.Metrics.Enabled {
-		metricsAddress := ":" + env.Config.Metrics.Port
+		metricsAddress := env.Config.Metrics.Host + ":" + env.Config.Metrics.Port
 		e.metricsServer = newMetricsServer(metricsAddress)
 		go func() {
 			err := e.metricsServer.ListenAndServe()


### PR DESCRIPTION
This PR adds support for configuring listen IP using the HOST (and METRICS_HOST) env var. Some environments need this to run securely (my use case is running fider on Nomad, and exposing it through the Consul service mesh, which requires service to bind on 127.0.0.1 to prevent random other allocation from bypassing defined ACL)