### PR TITLE
Fix typo in the "Deprecated" comment

### DIFF
--- a/app/services/sqlstore/postgres/common.go
+++ b/app/services/sqlstore/postgres/common.go
@@ -62,23 +62,23 @@ func getViewData(query query.SearchPosts) (string, []enum.PostStatus, string) {
 	case "most-discussed":
 		sort = "comments_count"
 	case "my-votes":
-		// Depracated: You can instead filter on my votes only for more flexibility than using this view.
+		// Deprecated: You can instead filter on my votes only for more flexibility than using this view.
 		condition = "AND has_voted = true"
 		sort = "id"
 	case "planned":
-		// Depracated: Use status filters instead
+		// Deprecated: Use status filters instead
 		sort = "response_date"
 		statusFilters = []enum.PostStatus{enum.PostPlanned}
 	case "started":
-		// Depracated: Use status filters instead
+		// Deprecated: Use status filters instead
 		sort = "response_date"
 		statusFilters = []enum.PostStatus{enum.PostStarted}
 	case "completed":
-		// Depracated: Use status filters instead
+		// Deprecated: Use status filters instead
 		sort = "response_date"
 		statusFilters = []enum.PostStatus{enum.PostCompleted}
 	case "declined":
-		// Depracated: Use status filters instead
+		// Deprecated: Use status filters instead
 		sort = "response_date"
 		statusFilters = []enum.PostStatus{enum.PostDeclined}
 	case "all":


### PR DESCRIPTION
Correct `Depracated` to `Deprecated`.