### PR TITLE
FIx search with hyphenated words.

### DIFF
--- a/app/services/sqlstore/postgres/common.go
+++ b/app/services/sqlstore/postgres/common.go
@@ -18,7 +18,7 @@ var replaceOr = strings.NewReplacer("|", " ")
 
 // ToTSQuery converts input to another string that can be safely used for ts_query
 func ToTSQuery(input string) string {
-	input = replaceOr.Replace(allowedTextRunes.ReplaceAllString(input, ""))
+	input = replaceOr.Replace(allowedTextRunes.ReplaceAllString(input, " "))
 	return strings.Join(strings.Fields(input), "|")
 }
 

--- a/app/services/sqlstore/postgres/common_test.go
+++ b/app/services/sqlstore/postgres/common_test.go
@@ -28,6 +28,8 @@ func TestToTSQuery(t *testing.T) {
 		{"hello|world", "hello|world"},
 		{"hello | world", "hello|world"},
 		{"hello & world", "hello|world"},
+		{"node-js", "node|js"},
+		{"real-time updates", "real|time|updates"},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
**Issue:** Fixes #1435 by adding a space to the results

The search was failing for hyphenated terms like "node-js" because the ToTSQuery function was stripping special characters by replacing them with an empty string, causing "node-js" to become "nodejs" as a single token. However, PostgreSQL's full-text search indexes hyphenated words as separate tokens ("node" and "js"), so searching for "nodejs" found no matches. The fix changes the replacement from an empty string to a space, so "node-js" becomes "node js", which then gets converted to "node|js" (an OR query). This matches how PostgreSQL tokenizes the indexed content, allowing hyphenated search terms to work correctly.
