### PR TITLE
Fix typo in donations section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you do self-host and enjoy Fider, please [let us know where you're using it](
 
 # 💰 Donations and Sponsors
 
-Supoprt the development of Fider to help us make it the best feedback tool! You can set up donations as small or large as you want to help us keep Fider going. [Donate](https://opencollective.com/fider)
+Support the development of Fider to help us make it the best feedback tool! You can set up donations as small or large as you want to help us keep Fider going. [Donate](https://opencollective.com/fider)
 
 If your organization uses Fider, consider becoming a sponsor - set up a monthly donation and get your logo and link on the README. [Become a sponsor](https://opencollective.com/fider)
 


### PR DESCRIPTION
First of all, thanks for building such a solid tool!

I was looking for prod-grade customer feedback platforms to self-host and Astuto's [goodbye message](https://github.com/astuto/astuto/issues/487) brought me here.

Spotted this tiny typo while 🧿-ing the codebase.
