### PR TITLE
fix: Context.BaseURL() returns full BASE_URL in single-host mode

### DIFF
--- a/app/pkg/web/context.go
+++ b/app/pkg/web/context.go
@@ -381,6 +381,9 @@ func (c *Context) RemoveCookie(name string) {
 
 // BaseURL returns base URL
 func (c *Context) BaseURL() string {
+	if env.IsSingleHostMode() {
+		return env.Config.BaseURL
+	}
 	return c.Request.BaseURL()
 }
 

--- a/app/pkg/web/context_test.go
+++ b/app/pkg/web/context_test.go
@@ -51,6 +51,7 @@ func TestContextID(t *testing.T) {
 
 func TestBaseURL(t *testing.T) {
 	RegisterT(t)
+	env.Config.HostMode = "multi"
 
 	ctx := newGetContext("http://demo.test.fider.io:3000", nil)
 
@@ -59,6 +60,7 @@ func TestBaseURL(t *testing.T) {
 
 func TestBaseURL_HTTPS(t *testing.T) {
 	RegisterT(t)
+	env.Config.HostMode = "multi"
 
 	ctx := newGetContext("https://demo.test.fider.io:3000", nil)
 
@@ -67,12 +69,33 @@ func TestBaseURL_HTTPS(t *testing.T) {
 
 func TestBaseURL_HTTPS_Proxy(t *testing.T) {
 	RegisterT(t)
+	env.Config.HostMode = "multi"
 
 	ctx := newGetContext("http://demo.test.fider.io:3000", map[string]string{
 		"X-Forwarded-Proto": "https",
 	})
 
 	Expect(ctx.BaseURL()).Equals("https://demo.test.fider.io:3000")
+}
+
+func TestBaseURL_SingleHostMode(t *testing.T) {
+	RegisterT(t)
+	env.Config.HostMode = "single"
+	env.Config.BaseURL = "https://example.com"
+
+	ctx := newGetContext("http://demo.test.fider.io:3000", nil)
+
+	Expect(ctx.BaseURL()).Equals("https://example.com")
+}
+
+func TestBaseURL_SingleHostMode_WithPath(t *testing.T) {
+	RegisterT(t)
+	env.Config.HostMode = "single"
+	env.Config.BaseURL = "https://example.com/feedback"
+
+	ctx := newGetContext("http://demo.test.fider.io:3000", nil)
+
+	Expect(ctx.BaseURL()).Equals("https://example.com/feedback")
 }
 
 func TestCurrentURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Fixes #1452**: `Context.BaseURL()` now returns `env.Config.BaseURL` (which includes the path component) when running in single-host mode, instead of calling `Request.BaseURL()` which strips the path.
- This is the root cause of sub-path hosting being broken — the renderer passes `ctx.BaseURL()` to the frontend as `Fider.settings.baseURL`, so the path component (e.g., `/feedback`) was being lost.
- Added two new unit tests (`TestBaseURL_SingleHostMode` and `TestBaseURL_SingleHostMode_WithPath`) and updated three existing tests to explicitly set `HostMode = "multi"`.

## Test plan
- [x] All 5 BaseURL tests pass (`TestBaseURL`, `TestBaseURL_HTTPS`, `TestBaseURL_HTTPS_Proxy`, `TestBaseURL_SingleHostMode`, `TestBaseURL_SingleHostMode_WithPath`)
- [ ] `go vet` passes on the changed package
- [ ] Deploy with `BASE_URL=https://example.com/feedback` and verify `Fider.settings.baseURL` includes `/feedback` in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)