### PR TITLE
Fix: Use strong key for sign-in email link

### DIFF
--- a/app/actions/signin.go
+++ b/app/actions/signin.go
@@ -16,11 +16,13 @@ import (
 type SignInByEmail struct {
 	Email            string `json:"email" format:"lower"`
 	VerificationCode string
+	LinkKey          string
 }
 
 func NewSignInByEmail() *SignInByEmail {
 	return &SignInByEmail{
 		VerificationCode: entity.GenerateEmailVerificationCode(),
+		LinkKey:          entity.GenerateEmailVerificationKey(),
 	}
 }
 
@@ -118,11 +120,13 @@ type SignInByEmailWithName struct {
 	Email            string `json:"email" format:"lower"`
 	Name             string `json:"name"`
 	VerificationCode string
+	LinkKey          string
 }
 
 func NewSignInByEmailWithName() *SignInByEmailWithName {
 	return &SignInByEmailWithName{
 		VerificationCode: entity.GenerateEmailVerificationCode(),
+		LinkKey:          entity.GenerateEmailVerificationKey(),
 	}
 }
 

--- a/app/handlers/signin.go
+++ b/app/handlers/signin.go
@@ -87,7 +87,8 @@ func SignInByEmail() web.HandlerFunc {
 		// Only send code if user exists
 		if userExists {
 			err := bus.Dispatch(c, &cmd.SaveVerificationKey{
-				Key:      action.VerificationCode,
+				Key:      action.LinkKey,
+				Code:     action.VerificationCode,
 				Duration: 15 * time.Minute,
 				Request:  action,
 			})
@@ -95,7 +96,7 @@ func SignInByEmail() web.HandlerFunc {
 				return c.Failure(err)
 			}
 
-			c.Enqueue(tasks.SendSignInEmail(action.Email, action.VerificationCode))
+			c.Enqueue(tasks.SendSignInEmail(action.Email, action.LinkKey, action.VerificationCode))
 		}
 
 		return c.Ok(web.Map{
@@ -129,7 +130,8 @@ func SignInByEmailWithName() web.HandlerFunc {
 
 		// Save verification with name
 		err = bus.Dispatch(c, &cmd.SaveVerificationKey{
-			Key:      action.VerificationCode,
+			Key:      action.LinkKey,
+			Code:     action.VerificationCode,
 			Duration: 15 * time.Minute,
 			Request:  action,
 		})
@@ -137,7 +139,7 @@ func SignInByEmailWithName() web.HandlerFunc {
 			return c.Failure(err)
 		}
 
-		c.Enqueue(tasks.SendSignInEmail(action.Email, action.VerificationCode))
+		c.Enqueue(tasks.SendSignInEmail(action.Email, action.LinkKey, action.VerificationCode))
 
 		return c.Ok(web.Map{})
 	}
@@ -169,18 +171,20 @@ func VerifySignInCode() web.HandlerFunc {
 
 		result := verification.Result
 
-		// Check if already verified (with grace period)
+		// Code is single-use: reject if already verified
 		if result.VerifiedAt != nil {
-			if time.Since(*result.VerifiedAt) > 5*time.Minute {
-				return c.Gone()
-			}
-		} else {
-			// Check if expired
-			if time.Now().After(result.ExpiresAt) {
-				// Mark as verified to prevent reuse
-				_ = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: action.Code})
-				return c.Gone()
-			}
+			return c.BadRequest(web.Map{
+				"code": "Invalid or expired verification code",
+			})
+		}
+
+		// Check if expired
+		if time.Now().After(result.ExpiresAt) {
+			// Mark as verified to prevent reuse
+			_ = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: result.Key})
+			return c.BadRequest(web.Map{
+				"code": "Invalid or expired verification code",
+			})
 		}
 
 		// Check if user exists
@@ -207,7 +211,7 @@ func VerifySignInCode() web.HandlerFunc {
 					}
 
 					// Mark code as verified
-					err = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: action.Code})
+					err = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: result.Key})
 					if err != nil {
 						return c.Failure(err)
 					}
@@ -226,7 +230,7 @@ func VerifySignInCode() web.HandlerFunc {
 		}
 
 		// Mark code as verified
-		err = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: action.Code})
+		err = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: result.Key})
 		if err != nil {
 			return c.Failure(err)
 		}
@@ -254,7 +258,8 @@ func ResendSignInCode() web.HandlerFunc {
 
 		// Save new verification code
 		err := bus.Dispatch(c, &cmd.SaveVerificationKey{
-			Key:      action.VerificationCode,
+			Key:      action.LinkKey,
+			Code:     action.VerificationCode,
 			Duration: 15 * time.Minute,
 			Request:  action,
 		})
@@ -263,7 +268,7 @@ func ResendSignInCode() web.HandlerFunc {
 		}
 
 		// Send new email
-		c.Enqueue(tasks.SendSignInEmail(action.Email, action.VerificationCode))
+		c.Enqueue(tasks.SendSignInEmail(action.Email, action.LinkKey, action.VerificationCode))
 
 		return c.Ok(web.Map{})
 	}

--- a/app/handlers/signin_test.go
+++ b/app/handlers/signin_test.go
@@ -57,7 +57,8 @@ func TestSignInByEmailHandler_ExistingUser(t *testing.T) {
 		ExecutePost(handlers.SignInByEmail(), `{ "email": "jon.snow@got.com" }`)
 
 	Expect(code).Equals(http.StatusOK)
-	Expect(saveKeyCmd.Key).HasLen(6)
+	Expect(saveKeyCmd.Key).HasLen(64)
+	Expect(saveKeyCmd.Code).HasLen(6)
 	Expect(saveKeyCmd.Request.GetKind()).Equals(enum.EmailVerificationKindSignIn)
 	Expect(saveKeyCmd.Request.GetEmail()).Equals("jon.snow@got.com")
 	Expect(response.Body.String()).ContainsSubstring(`"userExists":true`)
@@ -98,7 +99,8 @@ func TestSignInByEmailWithNameHandler_NewUser(t *testing.T) {
 		ExecutePost(handlers.SignInByEmailWithName(), `{ "email": "new.user@got.com", "name": "New User" }`)
 
 	Expect(code).Equals(http.StatusOK)
-	Expect(saveKeyCmd.Key).HasLen(6)
+	Expect(saveKeyCmd.Key).HasLen(64)
+	Expect(saveKeyCmd.Code).HasLen(6)
 	Expect(saveKeyCmd.Request.GetKind()).Equals(enum.EmailVerificationKindSignIn)
 	Expect(saveKeyCmd.Request.GetEmail()).Equals("new.user@got.com")
 	Expect(saveKeyCmd.Request.GetName()).Equals("New User")
@@ -820,7 +822,7 @@ func TestVerifySignInCodeHandler_ExpiredCode(t *testing.T) {
 		OnTenant(mock.DemoTenant).
 		ExecutePost(handlers.VerifySignInCode(), `{ "email": "jon.snow@got.com", "code": "123456" }`)
 
-	Expect(code).Equals(http.StatusGone)
+	Expect(code).Equals(http.StatusBadRequest)
 }
 
 func TestVerifySignInCodeHandler_CorrectCode_ExistingUser(t *testing.T) {
@@ -951,6 +953,29 @@ func TestVerifySignInCodeHandler_CorrectCode_NewUser_PrivateTenant(t *testing.T)
 	Expect(code).Equals(http.StatusForbidden)
 }
 
+func TestVerifySignInCodeHandler_AlreadyVerifiedCode_ShouldReject(t *testing.T) {
+	RegisterT(t)
+
+	verifiedAt := time.Now().Add(-1 * time.Minute)
+	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+		q.Result = &entity.EmailVerification{
+			Email:      "jon.snow@got.com",
+			Key:        "some-long-link-key",
+			CreatedAt:  time.Now().Add(-10 * time.Minute),
+			ExpiresAt:  time.Now().Add(5 * time.Minute),
+			VerifiedAt: &verifiedAt,
+		}
+		return nil
+	})
+
+	server := mock.NewServer()
+	code, _ := server.
+		OnTenant(mock.DemoTenant).
+		ExecutePost(handlers.VerifySignInCode(), `{ "email": "jon.snow@got.com", "code": "123456" }`)
+
+	Expect(code).Equals(http.StatusBadRequest)
+}
+
 func TestResendSignInCodeHandler_ValidEmail(t *testing.T) {
 	RegisterT(t)
 
@@ -966,7 +991,8 @@ func TestResendSignInCodeHandler_ValidEmail(t *testing.T) {
 		ExecutePost(handlers.ResendSignInCode(), `{ "email": "jon.snow@got.com" }`)
 
 	Expect(code).Equals(http.StatusOK)
-	Expect(saveKeyCmd.Key).HasLen(6)
+	Expect(saveKeyCmd.Key).HasLen(64)
+	Expect(saveKeyCmd.Code).HasLen(6)
 	Expect(saveKeyCmd.Request.GetKind()).Equals(enum.EmailVerificationKindSignIn)
 	Expect(saveKeyCmd.Request.GetEmail()).Equals("jon.snow@got.com")
 }

--- a/app/models/cmd/tenant.go
+++ b/app/models/cmd/tenant.go
@@ -47,6 +47,7 @@ type ActivateTenant struct {
 
 type SaveVerificationKey struct {
 	Key      string
+	Code     string
 	Duration time.Duration
 	Request  NewEmailVerification
 }

--- a/app/services/sqlstore/postgres/tenant.go
+++ b/app/services/sqlstore/postgres/tenant.go
@@ -145,7 +145,7 @@ func getVerificationByEmailAndCode(ctx context.Context, q *query.GetVerification
 	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
 		verification := dbEntities.EmailVerification{}
 
-		query := "SELECT id, email, name, key, created_at, verified_at, expires_at, kind, user_id FROM email_verifications WHERE tenant_id = $1 AND email = $2 AND key = $3 AND kind = $4 LIMIT 1"
+		query := "SELECT id, email, name, key, created_at, verified_at, expires_at, kind, user_id FROM email_verifications WHERE tenant_id = $1 AND email = $2 AND code = $3 AND kind = $4 LIMIT 1"
 		err := trx.Get(&verification, query, tenant.ID, q.Email, q.Code, q.Kind)
 		if err != nil {
 			return errors.Wrap(err, "failed to get email verification by email and code")
@@ -163,8 +163,13 @@ func saveVerificationKey(ctx context.Context, c *cmd.SaveVerificationKey) error 
 			userID = c.Request.GetUser().ID
 		}
 
-		query := "INSERT INTO email_verifications (tenant_id, email, created_at, expires_at, key, name, kind, user_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
-		_, err := trx.Execute(query, tenant.ID, c.Request.GetEmail(), time.Now(), time.Now().Add(c.Duration), c.Key, c.Request.GetName(), c.Request.GetKind(), userID)
+		var code any
+		if c.Code != "" {
+			code = c.Code
+		}
+
+		query := "INSERT INTO email_verifications (tenant_id, email, created_at, expires_at, key, name, kind, user_id, code) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"
+		_, err := trx.Execute(query, tenant.ID, c.Request.GetEmail(), time.Now(), time.Now().Add(c.Duration), c.Key, c.Request.GetName(), c.Request.GetKind(), userID, code)
 		if err != nil {
 			return errors.Wrap(err, "failed to save verification key for kind '%d'", c.Request.GetKind())
 		}

--- a/app/tasks/signin.go
+++ b/app/tasks/signin.go
@@ -9,12 +9,12 @@ import (
 )
 
 // SendSignInEmail is used to send the sign in email to requestor
-func SendSignInEmail(email, verificationCode string) worker.Task {
+func SendSignInEmail(email, linkKey, code string) worker.Task {
 	return describe("Send sign in email", func(c *worker.Context) error {
 		to := dto.NewRecipient("", email, dto.Props{
 			"siteName": c.Tenant().Name,
-			"code":     verificationCode,
-			"link":     link(web.BaseURL(c), "/signin/verify?k=%s", verificationCode),
+			"code":     code,
+			"link":     link(web.BaseURL(c), "/signin/verify?k=%s", linkKey),
 		})
 
 		bus.Publish(c, &cmd.SendMail{

--- a/app/tasks/signin_test.go
+++ b/app/tasks/signin_test.go
@@ -16,7 +16,7 @@ func TestSendSignInEmailTask(t *testing.T) {
 	bus.Init(emailmock.Service{})
 
 	worker := mock.NewWorker()
-	task := tasks.SendSignInEmail("jon@got.com", "9876")
+	task := tasks.SendSignInEmail("jon@got.com", "theLinkKey123", "987654")
 
 	err := worker.
 		OnTenant(mock.DemoTenant).
@@ -39,8 +39,8 @@ func TestSendSignInEmailTask(t *testing.T) {
 		Address: "jon@got.com",
 		Props: dto.Props{
 			"siteName": mock.DemoTenant.Name,
-			"code":     "9876",
-			"link":     "<a href='http://domain.com/signin/verify?k=9876'>http://domain.com/signin/verify?k=9876</a>",
+			"code":     "987654",
+			"link":     "<a href='http://domain.com/signin/verify?k=theLinkKey123'>http://domain.com/signin/verify?k=theLinkKey123</a>",
 		},
 	})
 }

--- a/migrations/202602250001_add_verification_code_column.sql
+++ b/migrations/202602250001_add_verification_code_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE email_verifications ADD COLUMN code VARCHAR(6) NULL;


### PR DESCRIPTION
Fixes #1458 

## Summary
- The sign-in email link previously used the same 6-digit numeric code as the manual entry flow, making it brute-forceable (only 1,000,000 possible values, no email required for the link flow)
- Now generates a separate 64-char cryptographic `link_key` for the email URL, while keeping the 6-digit code for manual entry (which requires the email address, limiting the attack surface)
- Makes the 6-digit code single-use — reuse now returns a 400 error instead of allowing re-authentication

## Test plan
- [x] `make lint` passes
- [x] All existing tests updated and passing
- [x] New test added: `TestVerifySignInCodeHandler_AlreadyVerifiedCode_ShouldReject`
- [x] Run `make migrate` to apply the new `code` column migration
- [x] Manual: trigger sign-in, verify email link uses a long key, verify 6-digit code works for manual entry
- [x] Manual: verify that reusing a 6-digit code after successful sign-in is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)