### PR TITLE
Fix authenticated arbitrary blob overwrite vulnerability

### DIFF
--- a/app/services/sqlstore/postgres/attachment.go
+++ b/app/services/sqlstore/postgres/attachment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/getfider/fider/app/models/cmd"
 	"github.com/getfider/fider/app/models/entity"
@@ -95,9 +96,17 @@ func getAttachments(ctx context.Context, q *query.GetAttachments) error {
 
 func uploadImage(ctx context.Context, c *cmd.UploadImage) error {
 	if c.Image.Upload != nil && len(c.Image.Upload.Content) > 0 {
-		if c.Image.BlobKey == "" {
+		// Regenerate key if empty or wrong folder prefix (prevents cross-folder overwrites)
+		if c.Image.BlobKey == "" || !strings.HasPrefix(c.Image.BlobKey, c.Folder+"/") {
 			c.Image.BlobKey = fmt.Sprintf("%s/%s-%s", c.Folder, rand.String(64), blob.SanitizeFileName(c.Image.Upload.FileName))
 		}
+
+		// If a blob already exists at this key, generate a new key to prevent overwriting
+		existsQ := &query.GetBlobByKey{Key: c.Image.BlobKey}
+		if err := bus.Dispatch(ctx, existsQ); err == nil {
+			c.Image.BlobKey = fmt.Sprintf("%s/%s-%s", c.Folder, rand.String(64), blob.SanitizeFileName(c.Image.Upload.FileName))
+		}
+
 		err := bus.Dispatch(ctx, &cmd.StoreBlob{
 			Key:         c.Image.BlobKey,
 			Content:     c.Image.Upload.Content,

--- a/app/services/sqlstore/postgres/attachment_test.go
+++ b/app/services/sqlstore/postgres/attachment_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/getfider/fider/app/models/cmd"
 	"github.com/getfider/fider/app/models/dto"
+	"github.com/getfider/fider/app/models/query"
 
 	. "github.com/getfider/fider/app/pkg/assert"
 	"github.com/getfider/fider/app/pkg/bus"
+	"github.com/getfider/fider/app/services/blob"
 )
 
 func TestUploadImage(t *testing.T) {
@@ -17,6 +19,9 @@ func TestUploadImage(t *testing.T) {
 
 	bus.AddHandler(func(ctx context.Context, c *cmd.StoreBlob) error {
 		return nil
+	})
+	bus.AddHandler(func(ctx context.Context, q *query.GetBlobByKey) error {
+		return blob.ErrNotFound
 	})
 
 	uploadImage := &cmd.UploadImage{
@@ -61,6 +66,9 @@ func TestUploadMultipleImages(t *testing.T) {
 
 	bus.AddHandler(func(ctx context.Context, c *cmd.StoreBlob) error {
 		return nil
+	})
+	bus.AddHandler(func(ctx context.Context, q *query.GetBlobByKey) error {
+		return blob.ErrNotFound
 	})
 
 	uploadImages := &cmd.UploadImages{


### PR DESCRIPTION
Summary: Prevent authenticated users from overwriting arbitrary blobs (logos, avatars, other users attachments) by supplying crafted bkey values in image upload payloads. Adds folder prefix validation and blob existence checks in uploadImage. The uploadImage function previously accepted client-provided blob keys verbatim. Combined with the ON CONFLICT DO UPDATE upsert in storeBlob, any authenticated user could overwrite any blob within their tenant by setting the bkey JSON field to a known key. Blob keys are trivially discoverable in page source and API responses.