### PR TITLE
Fixed users tab in administrative view not being highlighted when active

### DIFF
--- a/public/pages/Administration/pages/ManageMembers.page.tsx
+++ b/public/pages/Administration/pages/ManageMembers.page.tsx
@@ -215,7 +215,7 @@ export default function ManageMembersPage(props: ManageMembersPageProps) {
   )
 
   return (
-    <AdminPageContainer id="p-admin-members" name="members" title="Members" subtitle="Manage your site administrators and collaborators">
+    <AdminPageContainer id="p-admin-members" name="users" title="Members" subtitle="Manage your site administrators and collaborators">
       <div className="flex gap-4 flex-items-center mb-4">
         <div className="flex-grow">
           <Input


### PR DESCRIPTION
Found a little bug: The users tab in the administrative view was no longer being visible marked as the "active" tab.
<img width="303" height="385" alt="Screenshot 2026-04-18 at 07 31 59" src="https://github.com/user-attachments/assets/0414c609-b993-4b7e-9164-26b5b5b1a951" />

A different solution could also be, that you rename the menu item to members, because the heading of this tab talkes about members. But I didn't want to change the user interface here to keep the solution simple and straight forward.