### PR TITLE
fix: use 'zh' MessageFormatCode for Chinese (Traditional)

### DIFF
--- a/app/models/enum/locale.go
+++ b/app/models/enum/locale.go
@@ -183,7 +183,7 @@ var (
 	LocaleChineseTW = Locale{
 		Code:              "zh-TW",
 		Name:              "Chinese (Traditional)",
-		MessageFormatCode: "zh-tw",
+		MessageFormatCode: "zh",
 		PostgresConfig:    "simple",
 		LinguaLanguage:    lingua.Chinese,
 		IsRTL:             false,


### PR DESCRIPTION
## Summary

The `MessageFormatCode` for `LocaleChineseTW` is set to `zh-tw`, which is not a recognized culture by `gotnospirit/messageformat`. This causes any email template render to panic when the tenant locale is `zh-TW`.

Align with `LocaleChineseCN` which uses `zh` successfully.

## Reproduction

1. Self-host Fider on `main` branch (commit `a738f72` or later, where zh-TW was added)
2. Site Settings → Locale → select **Chinese (Traditional)**
3. Sign out and try to sign in with email → magic link is never sent

## Observed panic

```
template: signin_email.html:1:23: executing "subject" at <translate "email.signin_email.subject" ...>: error calling translate: Error Trace:
- failed create parser (app/pkg/i18n/i18n.go:59)
- UnknownCulture: `zh-tw`
[BGW] Task 'Send sign in email' finished in 3ms (panicked)
```

Trace originates at `messageformat.NewWithCulture(localeInfo.MessageFormatCode)` where `MessageFormatCode == "zh-tw"`.

## Fix

One-line change in `app/models/enum/locale.go`: `MessageFormatCode: "zh-tw"` → `"zh"`.

zh-CN uses the same `"zh"` code and works correctly. Pluralization rules for Chinese are identical between simplified and traditional, so sharing `zh` is correct.

## Test plan

- [x] Verified locally that zh-TW tenant could not send sign-in emails on `main`
- [x] Confirmed culture `zh-tw` is not in `gotnospirit/messageformat`'s culture list
- [ ] After merge, rebuild `:main` Docker image and retest