### PR TITLE
fix(email): unescape HTML entities in rendered subject

### DIFF
--- a/app/services/email/email_test.go
+++ b/app/services/email/email_test.go
@@ -10,6 +10,20 @@ import (
 	. "github.com/getfider/fider/app/pkg/assert"
 )
 
+func TestRenderMessage_SubjectUnescapesHTMLEntities(t *testing.T) {
+	RegisterT(t)
+
+	// Reproducer for the issue where characters like '+', '"', '&', '<', '>'
+	// in the rendered subject ended up as their numeric HTML entities
+	// (e.g. "&#43;", "&#34;") because the subject is rendered through
+	// html/template along with the body. SMTP headers are plain text and
+	// must contain the literal characters.
+	message := email.RenderMessage(context.Background(), "echo_test", email.NoReply, dto.Props{
+		"name": `Encontrar+se "quoted" & <tagged>`,
+	})
+	Expect(message.Subject).Equals(`Message to: Encontrar+se "quoted" & <tagged>`)
+}
+
 func TestRenderMessage(t *testing.T) {
 	RegisterT(t)
 

--- a/app/services/email/message.go
+++ b/app/services/email/message.go
@@ -3,6 +3,7 @@ package email
 import (
 	"bytes"
 	"context"
+	"html"
 	"mime"
 	"strings"
 	"unicode"
@@ -53,8 +54,15 @@ func RenderMessage(ctx context.Context, templateName string, fromAddress string,
 	lines := strings.Split(bf.String(), "\n")
 	body := strings.TrimLeft(strings.Join(lines[2:], "\n"), " ")
 
+	// The subject is rendered through html/template (because it shares the
+	// template set with the HTML body), which escapes characters like '+',
+	// '"', '&', '<', '>' to numeric entities (e.g. "&#43;"). SMTP headers
+	// are plain text and clients do not decode HTML entities in them, so
+	// undo the escaping for the subject only.
+	subject := html.UnescapeString(strings.TrimLeft(lines[0], "subject: "))
+
 	return &Message{
-		Subject: strings.TrimLeft(lines[0], "subject: "),
+		Subject: subject,
 		Body:    body,
 	}
 }


### PR DESCRIPTION
## Bug

Email subjects rendered with characters like `+`, `"`, `&`, `<`, `>` arrive in clients as their HTML numeric entities. Real-world example seen on a self-hosted instance:

> Subject: `[Plataforma da Encontrar&#43;se] Two columns of &#34;status&#34;`

Any site name or post title containing one of those characters is affected — quotes in titles are common, so most non-trivial use is hit.

## Cause

The subject template (`{{define "subject"}}…{{end}}`) shares the template set with the HTML body and is rendered via `html/template`. Go's `htmlReplacementTable` escapes `+ " ' & < >` to numeric entities (UTF-7 / JS-injection defense). Correct for HTML body, wrong for the SMTP `Subject:` header — that header is plain text and clients do not HTML-decode it.

## Fix

Run `html.UnescapeString` on the extracted subject inside `RenderMessage`. Body rendering is unchanged.

## Test

`TestRenderMessage_SubjectUnescapesHTMLEntities` posts a name containing `+ " & < >` through the existing `echo_test` template and asserts the literal characters survive in the subject. Verified to fail on `main` and pass with the fix.