### PR TITLE
Make post search respect active filters

### DIFF
--- a/app/services/sqlstore/postgres/common.go
+++ b/app/services/sqlstore/postgres/common.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -35,7 +36,7 @@ func MapLocaleToTSConfig(locale string) string {
 	return enum.MapLocaleToTSConfig(locale)
 }
 
-func getViewData(query query.SearchPosts) (string, []enum.PostStatus, string) {
+func getViewData(query query.SearchPosts, tagsPlaceholder int) (string, []enum.PostStatus, string) {
 	var (
 		condition string
 		sort      string
@@ -101,7 +102,7 @@ func getViewData(query query.SearchPosts) (string, []enum.PostStatus, string) {
 	}
 
 	if len(query.Tags) > 0 {
-		condition += " AND tags && $3"
+		condition += fmt.Sprintf(" AND tags && $%d", tagsPlaceholder)
 	}
 	return condition, statusFilters, sort
 }

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -450,21 +450,26 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 
 			score := fmt.Sprintf("ts_rank_cd(q.search, %s) + ts_rank_cd(q.search, %s)", tsQueryExpr, tsQuerySimple)
 
-			whereParts := fmt.Sprintf(`q.search @@ %s OR q.search @@ %s`, tsQueryExpr, tsQuerySimple)
+			searchPredicate := fmt.Sprintf(`q.search @@ %s OR q.search @@ %s`, tsQueryExpr, tsQuerySimple)
+
+			condition, statuses, _ := getViewData(*q, 4)
+
+			if q.MyPostsOnly {
+				condition += " AND user_id = " + strconv.Itoa(user.ID)
+			}
 
 			sql := fmt.Sprintf(`
 				SELECT * FROM (%s) AS q
-				WHERE %s
+				WHERE (%s) %s
 				ORDER BY %s DESC
 				LIMIT %s
-			`, innerQuery, whereParts, score, q.Limit)
-			err = trx.Select(&posts, sql, tenant.ID, pq.Array([]enum.PostStatus{
-				enum.PostOpen,
-				enum.PostStarted,
-				enum.PostPlanned,
-				enum.PostCompleted,
-				enum.PostDeclined,
-			}), tsQuery)
+			`, innerQuery, searchPredicate, condition, score, q.Limit)
+
+			params := []interface{}{tenant.ID, pq.Array(statuses), tsQuery}
+			if len(q.Tags) > 0 {
+				params = append(params, pq.Array(q.Tags))
+			}
+			err = trx.Select(&posts, sql, params...)
 		} else {
 			condition, statuses, sort := getViewData(*q, 3)
 

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -466,7 +466,7 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 				enum.PostDeclined,
 			}), tsQuery)
 		} else {
-			condition, statuses, sort := getViewData(*q)
+			condition, statuses, sort := getViewData(*q, 3)
 
 			if q.MyPostsOnly {
 				condition += " AND user_id = " + strconv.Itoa(user.ID)

--- a/app/services/sqlstore/postgres/post_test.go
+++ b/app/services/sqlstore/postgres/post_test.go
@@ -818,6 +818,113 @@ func TestGetPosts_Different_Statuses(t *testing.T) {
 
 }
 
+func TestSearchPosts_RespectsFilters(t *testing.T) {
+	SetupDatabaseTest(t)
+	defer TeardownDatabaseTest()
+
+	openPost := &cmd.AddNewPost{Title: "kanban open ticket", Description: "first kanban post"}
+	startedPost := &cmd.AddNewPost{Title: "kanban started flow", Description: "second kanban post"}
+	completedPost := &cmd.AddNewPost{Title: "kanban completed item", Description: "third kanban post"}
+	openByJon := &cmd.AddNewPost{Title: "kanban open from jon", Description: "fourth kanban post"}
+	err := bus.Dispatch(aryaStarkCtx, openPost, completedPost)
+	Expect(err).IsNil()
+	err = bus.Dispatch(jonSnowCtx, startedPost, openByJon)
+	Expect(err).IsNil()
+
+	bus.MustDispatch(aryaStarkCtx,
+		&cmd.SetPostResponse{Post: startedPost.Result, Text: "Working on it", Status: enum.PostStarted},
+		&cmd.SetPostResponse{Post: completedPost.Result, Text: "Done", Status: enum.PostCompleted},
+	)
+
+	addBug := &cmd.AddNewTag{Name: "Bug", Color: "FF0000", IsPublic: true}
+	bus.MustDispatch(aryaStarkCtx, addBug)
+	bus.MustDispatch(aryaStarkCtx, &cmd.AssignTag{Tag: addBug.Result, Post: startedPost.Result})
+
+	bus.MustDispatch(aryaStarkCtx, &cmd.AddVote{Post: openPost.Result, User: aryaStark})
+
+	testCases := []struct {
+		name          string
+		searchParams  *query.SearchPosts
+		expectedCount int
+		expectedIDs   []int
+	}{
+		{
+			name:          "Default search excludes Completed and Declined",
+			searchParams:  &query.SearchPosts{Query: "kanban"},
+			expectedCount: 3,
+			expectedIDs:   []int{openPost.Result.ID, startedPost.Result.ID, openByJon.Result.ID},
+		},
+		{
+			name: "Search with explicit Completed status",
+			searchParams: &query.SearchPosts{
+				Query:    "kanban",
+				Statuses: []enum.PostStatus{enum.PostCompleted},
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{completedPost.Result.ID},
+		},
+		{
+			name: "Search with explicit Open status",
+			searchParams: &query.SearchPosts{
+				Query:    "kanban",
+				Statuses: []enum.PostStatus{enum.PostOpen},
+			},
+			expectedCount: 2,
+			expectedIDs:   []int{openPost.Result.ID, openByJon.Result.ID},
+		},
+		{
+			name: "Search with tag filter",
+			searchParams: &query.SearchPosts{
+				Query: "kanban",
+				Tags:  []string{addBug.Result.Slug},
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{startedPost.Result.ID},
+		},
+		{
+			name: "Search with MyVotesOnly",
+			searchParams: &query.SearchPosts{
+				Query:       "kanban",
+				MyVotesOnly: true,
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{openPost.Result.ID},
+		},
+		{
+			name: "Search with MyPostsOnly",
+			searchParams: &query.SearchPosts{
+				Query:       "kanban",
+				MyPostsOnly: true,
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{openPost.Result.ID},
+		},
+		{
+			name: "Search with NoTagsOnly",
+			searchParams: &query.SearchPosts{
+				Query:      "kanban",
+				NoTagsOnly: true,
+			},
+			expectedCount: 2,
+			expectedIDs:   []int{openPost.Result.ID, openByJon.Result.ID},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err = bus.Dispatch(aryaStarkCtx, tc.searchParams)
+			Expect(err).IsNil()
+			Expect(tc.searchParams.Result).HasLen(tc.expectedCount)
+
+			foundIDs := make([]int, len(tc.searchParams.Result))
+			for i, post := range tc.searchParams.Result {
+				foundIDs[i] = post.ID
+			}
+			Expect(foundIDs).ContainsOnly(tc.expectedIDs)
+		})
+	}
+}
+
 func TestPostStorage_IsReferenced(t *testing.T) {
 	SetupDatabaseTest(t)
 	defer TeardownDatabaseTest()

--- a/public/pages/Home/components/PostsContainer.scss
+++ b/public/pages/Home/components/PostsContainer.scss
@@ -6,6 +6,19 @@
     grid-template-columns: 1fr 1fr 1fr 1fr;
     row-gap: spacing(4);
     margin-bottom: spacing(6);
+
+    &--searching {
+      @include media("md") {
+        grid-template-columns: auto 1fr;
+
+        .c-posts-container__filter-col {
+          grid-column: 1;
+        }
+        .c-posts-container__search-col {
+          grid-column: 2;
+        }
+      }
+    }
   }
 
   &__filter-col {

--- a/public/pages/Home/components/PostsContainer.tsx
+++ b/public/pages/Home/components/PostsContainer.tsx
@@ -161,10 +161,11 @@ export class PostsContainer extends React.Component<PostsContainerProps, PostsCo
 
   public render() {
     const showMoreLink = this.getShowMoreLink()
+    const headerClass = this.state.query ? "c-posts-container__header c-posts-container__header--searching" : "c-posts-container__header"
 
     return (
       <div className="c-posts-container">
-        <div className="c-posts-container__header">
+        <div className={headerClass}>
           <div className="c-posts-container__filter-col">
             <PostFilter
               tags={this.props.tags}

--- a/public/pages/Home/components/PostsContainer.tsx
+++ b/public/pages/Home/components/PostsContainer.tsx
@@ -165,17 +165,15 @@ export class PostsContainer extends React.Component<PostsContainerProps, PostsCo
     return (
       <div className="c-posts-container">
         <div className="c-posts-container__header">
-          {!this.state.query && (
-            <div className="c-posts-container__filter-col">
-              <PostFilter
-                tags={this.props.tags}
-                activeFilter={this.state.filterState}
-                filtersChanged={this.handleFilterChanged}
-                countPerStatus={this.props.countPerStatus}
-              />
-              <PostsSort onChange={this.handleSortChanged} value={this.state.view} />
-            </div>
-          )}
+          <div className="c-posts-container__filter-col">
+            <PostFilter
+              tags={this.props.tags}
+              activeFilter={this.state.filterState}
+              filtersChanged={this.handleFilterChanged}
+              countPerStatus={this.props.countPerStatus}
+            />
+            {!this.state.query && <PostsSort onChange={this.handleSortChanged} value={this.state.view} />}
+          </div>
           <div className="c-posts-container__search-col">
             <Input
               field="query"


### PR DESCRIPTION
## Summary

On the Home page, applying a status (or tag/my-votes/my-posts/untagged) filter and then typing in the search box previously dropped every filter — search returned posts of all five statuses with no tag/ownership filtering. The filter UI also disappeared the moment the search input got focus, so users had no way to see or change what was active.

This PR aligns the search branch of `searchPosts()` with the no-query branch so filters are honored consistently, and keeps the filter sidebar visible during search. Score-based ordering during search is preserved (the sort selector is hidden because it has no effect when results are ranked by `ts_rank_cd`).

- `getViewData()` now takes a `tagsPlaceholder int` so both call sites can use it (filter mode binds tags as `\$3`, search mode as `\$4`).
- The search branch calls `getViewData(*q, 4)` to get the same `condition` and `statuses` the no-query branch uses, applies `MyPostsOnly` the same way, wraps the OR full-text predicate in parens to avoid OR/AND precedence dropping filter rows, and binds `pq.Array(q.Tags)` as `\$4` only when present.
- `<PostFilter>` renders unconditionally; only `<PostsSort>` is gated on `!query`.

Default behavior change: a search request with no explicit status filter now returns only `[Open, Started, Planned]` (matches filter-mode default) instead of all five statuses. To include `Completed`/`Declined` posts in search results, the user can set those statuses explicitly.

## Bugs found while working on this

Code review surfaced two pre-existing edge cases in the same code paths:

1. \`MyPostsOnly\` panicked on anonymous API calls (nil deref on \`user.ID\`).
2. Setting \`NoTagsOnly\` and \`Tags\` together produces silently empty results — the UI doesn't enforce mutual exclusivity, so a user can reach the contradictory state with two clicks.

Both predate this change but became more reachable now that the search branch applies the same filter logic. Addressed in #1515 (stacked on top of this PR) to keep this one focused on the original bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)