### PR TITLE
Harden post filter against edge cases

### DIFF
--- a/app/services/sqlstore/postgres/common.go
+++ b/app/services/sqlstore/postgres/common.go
@@ -98,6 +98,9 @@ func getViewData(query query.SearchPosts, tagsPlaceholder int) (string, []enum.P
 	}
 
 	if query.NoTagsOnly {
+		// NoTagsOnly takes precedence: combining "untagged" with specific tag
+		// filters produces contradictory SQL that always returns zero rows.
+		query.Tags = nil
 		condition += " AND tags = '{}'"
 	}
 

--- a/app/services/sqlstore/postgres/common.go
+++ b/app/services/sqlstore/postgres/common.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -35,7 +36,7 @@ func MapLocaleToTSConfig(locale string) string {
 	return enum.MapLocaleToTSConfig(locale)
 }
 
-func getViewData(query query.SearchPosts) (string, []enum.PostStatus, string) {
+func getViewData(query query.SearchPosts, tagsPlaceholder int) (string, []enum.PostStatus, string) {
 	var (
 		condition string
 		sort      string
@@ -101,7 +102,7 @@ func getViewData(query query.SearchPosts) (string, []enum.PostStatus, string) {
 	}
 
 	if len(query.Tags) > 0 {
-		condition += " AND tags && $3"
+		condition += fmt.Sprintf(" AND tags && $%d", tagsPlaceholder)
 	}
 	return condition, statusFilters, sort
 }

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -450,21 +450,26 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 
 			score := fmt.Sprintf("ts_rank_cd(q.search, %s) + ts_rank_cd(q.search, %s)", tsQueryExpr, tsQuerySimple)
 
-			whereParts := fmt.Sprintf(`q.search @@ %s OR q.search @@ %s`, tsQueryExpr, tsQuerySimple)
+			searchPredicate := fmt.Sprintf(`q.search @@ %s OR q.search @@ %s`, tsQueryExpr, tsQuerySimple)
+
+			condition, statuses, _ := getViewData(*q, 4)
+
+			if q.MyPostsOnly {
+				condition += " AND user_id = " + strconv.Itoa(user.ID)
+			}
 
 			sql := fmt.Sprintf(`
 				SELECT * FROM (%s) AS q
-				WHERE %s
+				WHERE (%s) %s
 				ORDER BY %s DESC
 				LIMIT %s
-			`, innerQuery, whereParts, score, q.Limit)
-			err = trx.Select(&posts, sql, tenant.ID, pq.Array([]enum.PostStatus{
-				enum.PostOpen,
-				enum.PostStarted,
-				enum.PostPlanned,
-				enum.PostCompleted,
-				enum.PostDeclined,
-			}), tsQuery)
+			`, innerQuery, searchPredicate, condition, score, q.Limit)
+
+			params := []interface{}{tenant.ID, pq.Array(statuses), tsQuery}
+			if len(q.Tags) > 0 {
+				params = append(params, pq.Array(q.Tags))
+			}
+			err = trx.Select(&posts, sql, params...)
 		} else {
 			condition, statuses, sort := getViewData(*q, 3)
 

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -466,7 +466,7 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 				enum.PostDeclined,
 			}), tsQuery)
 		} else {
-			condition, statuses, sort := getViewData(*q)
+			condition, statuses, sort := getViewData(*q, 3)
 
 			if q.MyPostsOnly {
 				condition += " AND user_id = " + strconv.Itoa(user.ID)

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -466,7 +466,7 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 			`, innerQuery, searchPredicate, condition, score, q.Limit)
 
 			params := []interface{}{tenant.ID, pq.Array(statuses), tsQuery}
-			if len(q.Tags) > 0 {
+			if len(q.Tags) > 0 && !q.NoTagsOnly {
 				params = append(params, pq.Array(q.Tags))
 			}
 			err = trx.Select(&posts, sql, params...)
@@ -484,7 +484,7 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 				LIMIT %s
 			`, innerQuery, condition, sort, q.Limit)
 			params := []interface{}{tenant.ID, pq.Array(statuses)}
-			if len(q.Tags) > 0 {
+			if len(q.Tags) > 0 && !q.NoTagsOnly {
 				params = append(params, pq.Array(q.Tags))
 			}
 			err = trx.Select(&posts, sql, params...)

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -454,7 +454,7 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 
 			condition, statuses, _ := getViewData(*q, 4)
 
-			if q.MyPostsOnly {
+			if q.MyPostsOnly && user != nil {
 				condition += " AND user_id = " + strconv.Itoa(user.ID)
 			}
 
@@ -473,7 +473,7 @@ func searchPosts(ctx context.Context, q *query.SearchPosts) error {
 		} else {
 			condition, statuses, sort := getViewData(*q, 3)
 
-			if q.MyPostsOnly {
+			if q.MyPostsOnly && user != nil {
 				condition += " AND user_id = " + strconv.Itoa(user.ID)
 			}
 

--- a/app/services/sqlstore/postgres/post_test.go
+++ b/app/services/sqlstore/postgres/post_test.go
@@ -818,6 +818,113 @@ func TestGetPosts_Different_Statuses(t *testing.T) {
 
 }
 
+func TestSearchPosts_RespectsFilters(t *testing.T) {
+	SetupDatabaseTest(t)
+	defer TeardownDatabaseTest()
+
+	openPost := &cmd.AddNewPost{Title: "kanban open ticket", Description: "first kanban post"}
+	startedPost := &cmd.AddNewPost{Title: "kanban started flow", Description: "second kanban post"}
+	completedPost := &cmd.AddNewPost{Title: "kanban completed item", Description: "third kanban post"}
+	openByJon := &cmd.AddNewPost{Title: "kanban open from jon", Description: "fourth kanban post"}
+	err := bus.Dispatch(aryaStarkCtx, openPost, completedPost)
+	Expect(err).IsNil()
+	err = bus.Dispatch(jonSnowCtx, startedPost, openByJon)
+	Expect(err).IsNil()
+
+	bus.MustDispatch(aryaStarkCtx,
+		&cmd.SetPostResponse{Post: startedPost.Result, Text: "Working on it", Status: enum.PostStarted},
+		&cmd.SetPostResponse{Post: completedPost.Result, Text: "Done", Status: enum.PostCompleted},
+	)
+
+	addBug := &cmd.AddNewTag{Name: "Bug", Color: "FF0000", IsPublic: true}
+	bus.MustDispatch(aryaStarkCtx, addBug)
+	bus.MustDispatch(aryaStarkCtx, &cmd.AssignTag{Tag: addBug.Result, Post: startedPost.Result})
+
+	bus.MustDispatch(aryaStarkCtx, &cmd.AddVote{Post: openPost.Result, User: aryaStark})
+
+	testCases := []struct {
+		name          string
+		searchParams  *query.SearchPosts
+		expectedCount int
+		expectedIDs   []int
+	}{
+		{
+			name:          "Default search excludes Completed and Declined",
+			searchParams:  &query.SearchPosts{Query: "kanban"},
+			expectedCount: 3,
+			expectedIDs:   []int{openPost.Result.ID, startedPost.Result.ID, openByJon.Result.ID},
+		},
+		{
+			name: "Search with explicit Completed status",
+			searchParams: &query.SearchPosts{
+				Query:    "kanban",
+				Statuses: []enum.PostStatus{enum.PostCompleted},
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{completedPost.Result.ID},
+		},
+		{
+			name: "Search with explicit Open status",
+			searchParams: &query.SearchPosts{
+				Query:    "kanban",
+				Statuses: []enum.PostStatus{enum.PostOpen},
+			},
+			expectedCount: 2,
+			expectedIDs:   []int{openPost.Result.ID, openByJon.Result.ID},
+		},
+		{
+			name: "Search with tag filter",
+			searchParams: &query.SearchPosts{
+				Query: "kanban",
+				Tags:  []string{addBug.Result.Slug},
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{startedPost.Result.ID},
+		},
+		{
+			name: "Search with MyVotesOnly",
+			searchParams: &query.SearchPosts{
+				Query:       "kanban",
+				MyVotesOnly: true,
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{openPost.Result.ID},
+		},
+		{
+			name: "Search with MyPostsOnly",
+			searchParams: &query.SearchPosts{
+				Query:       "kanban",
+				MyPostsOnly: true,
+			},
+			expectedCount: 1,
+			expectedIDs:   []int{openPost.Result.ID},
+		},
+		{
+			name: "Search with NoTagsOnly",
+			searchParams: &query.SearchPosts{
+				Query:      "kanban",
+				NoTagsOnly: true,
+			},
+			expectedCount: 2,
+			expectedIDs:   []int{openPost.Result.ID, openByJon.Result.ID},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err = bus.Dispatch(aryaStarkCtx, tc.searchParams)
+			Expect(err).IsNil()
+			Expect(tc.searchParams.Result).HasLen(tc.expectedCount)
+
+			foundIDs := make([]int, len(tc.searchParams.Result))
+			for i, post := range tc.searchParams.Result {
+				foundIDs[i] = post.ID
+			}
+			Expect(foundIDs).ContainsOnly(tc.expectedIDs)
+		})
+	}
+}
+
 func TestPostStorage_IsReferenced(t *testing.T) {
 	SetupDatabaseTest(t)
 	defer TeardownDatabaseTest()

--- a/public/pages/Home/components/PostFilter.tsx
+++ b/public/pages/Home/components/PostFilter.tsx
@@ -76,9 +76,20 @@ export const PostFilter = (props: PostFilterProps) => {
 
   const handleChangeFilter = (item: OptionItem) => () => {
     const exists = filterItems.find((i) => i.type === item.type && i.value === item.value)
-    const newFilter = exists
-      ? filterItems.filter((i) => !(i.type === item.type && i.value === item.value))
-      : [...filterItems, { type: item.type, value: item.value }]
+    let newFilter: FilterItem[]
+    if (exists) {
+      newFilter = filterItems.filter((i) => !(i.type === item.type && i.value === item.value))
+    } else {
+      // "Untagged" and concrete tags are mutually exclusive — combining them
+      // produces an empty result set on the server.
+      let base = filterItems
+      if (item.type === "noTags") {
+        base = base.filter((i) => i.type !== "tag")
+      } else if (item.type === "tag") {
+        base = base.filter((i) => i.type !== "noTags")
+      }
+      newFilter = [...base, { type: item.type, value: item.value }]
+    }
 
     props.filtersChanged(FilterItemsToFilterState(newFilter))
     setQuery("")

--- a/public/pages/Home/components/PostsContainer.scss
+++ b/public/pages/Home/components/PostsContainer.scss
@@ -6,6 +6,19 @@
     grid-template-columns: 1fr 1fr 1fr 1fr;
     row-gap: spacing(4);
     margin-bottom: spacing(6);
+
+    &--searching {
+      @include media("md") {
+        grid-template-columns: auto 1fr;
+
+        .c-posts-container__filter-col {
+          grid-column: 1;
+        }
+        .c-posts-container__search-col {
+          grid-column: 2;
+        }
+      }
+    }
   }
 
   &__filter-col {

--- a/public/pages/Home/components/PostsContainer.tsx
+++ b/public/pages/Home/components/PostsContainer.tsx
@@ -161,10 +161,11 @@ export class PostsContainer extends React.Component<PostsContainerProps, PostsCo
 
   public render() {
     const showMoreLink = this.getShowMoreLink()
+    const headerClass = this.state.query ? "c-posts-container__header c-posts-container__header--searching" : "c-posts-container__header"
 
     return (
       <div className="c-posts-container">
-        <div className="c-posts-container__header">
+        <div className={headerClass}>
           <div className="c-posts-container__filter-col">
             <PostFilter
               tags={this.props.tags}

--- a/public/pages/Home/components/PostsContainer.tsx
+++ b/public/pages/Home/components/PostsContainer.tsx
@@ -165,17 +165,15 @@ export class PostsContainer extends React.Component<PostsContainerProps, PostsCo
     return (
       <div className="c-posts-container">
         <div className="c-posts-container__header">
-          {!this.state.query && (
-            <div className="c-posts-container__filter-col">
-              <PostFilter
-                tags={this.props.tags}
-                activeFilter={this.state.filterState}
-                filtersChanged={this.handleFilterChanged}
-                countPerStatus={this.props.countPerStatus}
-              />
-              <PostsSort onChange={this.handleSortChanged} value={this.state.view} />
-            </div>
-          )}
+          <div className="c-posts-container__filter-col">
+            <PostFilter
+              tags={this.props.tags}
+              activeFilter={this.state.filterState}
+              filtersChanged={this.handleFilterChanged}
+              countPerStatus={this.props.countPerStatus}
+            />
+            {!this.state.query && <PostsSort onChange={this.handleSortChanged} value={this.state.view} />}
+          </div>
           <div className="c-posts-container__search-col">
             <Input
               field="query"


### PR DESCRIPTION
## Summary

Two pre-existing edge cases in the Home post-filter, surfaced during code review of #1514. Neither is a regression introduced by that PR, but both became more reachable once the search branch started applying the same filter logic as filter mode.

**Depends on #1514** — fixes are stacked on top of that branch, since both bugs needed updates in the search branch added there. Merge #1514 first, then this one.

### Bug 1 — Anonymous \`MyPostsOnly\` panicked

Both branches of \`searchPosts()\` did \`condition += " AND user_id = " + strconv.Itoa(user.ID)\` whenever \`q.MyPostsOnly\` was set. On unauthenticated API calls (\`GET /api/v1/posts?myposts=true\`) \`user\` is \`nil\`, so this panicked. The frontend hides the option from anonymous visitors, but the API parameter was still accepted, so direct calls crashed the handler. Now the flag is silently ignored when there is no authenticated user.

### Bug 2 — \`NoTagsOnly\` + \`Tags\` returned silent empty results

\`getViewData()\` appended \`AND tags = '{}'\` and \`AND tags && \$N\` independently. When both were active the SQL was always false — the user got \`[]\` with no indication their filter combo was contradictory. The UI also didn't enforce mutual exclusivity (\`PostFilter\`'s "Untagged" checkbox and concrete tag checkboxes were independent toggles in the same section), so a user could reach this state with two clicks.

Defense in depth:

- **Backend:** \`NoTagsOnly\` now takes precedence in \`getViewData()\` — when set, the tag filter is dropped from both the SQL condition and the parameter list. Direct API callers, stale URL params, or scripted clients are all safe.
- **Frontend:** \`handleChangeFilter\` in \`PostFilter.tsx\` now clears the opposing filter type when toggling on — selecting "Untagged" deselects active tags, and selecting a tag deselects "Untagged".

🤖 Generated with [Claude Code](https://claude.com/claude-code)