### PR TITLE
Fix mass assignment auth bypass in sign-in verification

### DIFF
--- a/app/actions/invite.go
+++ b/app/actions/invite.go
@@ -20,9 +20,8 @@ type InviteUsers struct {
 	Subject        string   `json:"subject"`
 	Message        string   `json:"message"`
 	Recipients     []string `json:"recipients" format:"lower"`
-	IsSampleInvite bool
-
-	Invitations []*UserInvitation
+	IsSampleInvite bool              `json:"-"`
+	Invitations    []*UserInvitation `json:"-"`
 }
 
 // IsAuthorized returns true if current user is authorized to perform this action

--- a/app/actions/signin.go
+++ b/app/actions/signin.go
@@ -15,8 +15,8 @@ import (
 // SignInByEmail happens when user request to sign in by email
 type SignInByEmail struct {
 	Email            string `json:"email" format:"lower"`
-	VerificationCode string
-	LinkKey          string
+	VerificationCode string `json:"-"`
+	LinkKey          string `json:"-"`
 }
 
 func NewSignInByEmail() *SignInByEmail {
@@ -119,8 +119,8 @@ func (action *VerifySignInCode) Validate(ctx context.Context, user *entity.User)
 type SignInByEmailWithName struct {
 	Email            string `json:"email" format:"lower"`
 	Name             string `json:"name"`
-	VerificationCode string
-	LinkKey          string
+	VerificationCode string `json:"-"`
+	LinkKey          string `json:"-"`
 }
 
 func NewSignInByEmailWithName() *SignInByEmailWithName {

--- a/app/actions/signin_test.go
+++ b/app/actions/signin_test.go
@@ -2,6 +2,7 @@ package actions_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/getfider/fider/app/actions"
@@ -34,6 +35,42 @@ func TestSignInByEmail_ShouldHaveVerificationKey(t *testing.T) {
 	ExpectSuccess(result)
 	Expect(action.VerificationCode).IsNotEmpty()
 	Expect(len(action.VerificationCode)).Equals(6)
+}
+
+func TestSignInByEmail_VerificationCodeNotOverwrittenByJSON(t *testing.T) {
+	RegisterT(t)
+
+	action := actions.NewSignInByEmail()
+	originalCode := action.VerificationCode
+	originalKey := action.LinkKey
+
+	// Simulate attacker trying to overwrite internal fields via JSON binding
+	payload := []byte(`{"email":"attacker@evil.com","VerificationCode":"000000","LinkKey":"attacker-key"}`)
+	err := json.Unmarshal(payload, action)
+	Expect(err).IsNil()
+
+	// VerificationCode and LinkKey must NOT be overwritten
+	Expect(action.VerificationCode).Equals(originalCode)
+	Expect(action.LinkKey).Equals(originalKey)
+	// Email should still bind normally
+	Expect(action.Email).Equals("attacker@evil.com")
+}
+
+func TestSignInByEmailWithName_VerificationCodeNotOverwrittenByJSON(t *testing.T) {
+	RegisterT(t)
+
+	action := actions.NewSignInByEmailWithName()
+	originalCode := action.VerificationCode
+	originalKey := action.LinkKey
+
+	payload := []byte(`{"email":"attacker@evil.com","name":"Attacker","VerificationCode":"000000","LinkKey":"attacker-key"}`)
+	err := json.Unmarshal(payload, action)
+	Expect(err).IsNil()
+
+	Expect(action.VerificationCode).Equals(originalCode)
+	Expect(action.LinkKey).Equals(originalKey)
+	Expect(action.Email).Equals("attacker@evil.com")
+	Expect(action.Name).Equals("Attacker")
 }
 
 func TestCompleteProfile_EmptyNameAndKey(t *testing.T) {

--- a/app/actions/tenant.go
+++ b/app/actions/tenant.go
@@ -23,11 +23,11 @@ type CreateTenant struct {
 	Token           string `json:"token"`
 	Name            string `json:"name"`
 	Email           string `json:"email" format:"lower"`
-	VerificationKey string
-	TenantName      string `json:"tenantName"`
-	LegalAgreement  bool   `json:"legalAgreement"`
-	Subdomain       string `json:"subdomain" format:"lower"`
-	UserClaims      *jwt.OAuthClaims
+	VerificationKey string           `json:"-"`
+	TenantName      string           `json:"tenantName"`
+	LegalAgreement  bool             `json:"legalAgreement"`
+	Subdomain       string           `json:"subdomain" format:"lower"`
+	UserClaims      *jwt.OAuthClaims `json:"-"`
 }
 
 func NewCreateTenant() *CreateTenant {
@@ -119,7 +119,7 @@ func (action *CreateTenant) GetKind() enum.EmailVerificationKind {
 
 // ResendSignUpEmail is the input model used to resend signup verification email
 type ResendSignUpEmail struct {
-	VerificationKey string
+	VerificationKey string `json:"-"`
 }
 
 func NewResendSignUpEmail() *ResendSignUpEmail {

--- a/app/actions/user.go
+++ b/app/actions/user.go
@@ -95,8 +95,8 @@ func (action *ChangeUserRole) Validate(ctx context.Context, user *entity.User) *
 //ChangeUserEmail is the action used to change current user's email
 type ChangeUserEmail struct {
 	Email           string `json:"email" format:"lower"`
-	VerificationKey string
-	Requestor       *entity.User
+	VerificationKey string       `json:"-"`
+	Requestor       *entity.User `json:"-"`
 }
 
 func NewChangeUserEmail() *ChangeUserEmail {


### PR DESCRIPTION
Critical security fix: DefaultBinder.Bind uses json.Unmarshal which allowed attacker-controlled JSON to overwrite server-generated VerificationCode/LinkKey fields. An attacker could inject known OTP values and authenticate as any user. Added json:"-" tags to all sensitive internal fields and regression tests.