### PR TITLE
Add rate limiting to sign-in verification code

### DIFF
--- a/app/handlers/signin.go
+++ b/app/handlers/signin.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -97,6 +98,12 @@ func SignInByEmail() web.HandlerFunc {
 
 		// Only send code if user exists
 		if userExists {
+			// Invalidate any previous active verification codes for this email
+			_ = bus.Dispatch(c, &cmd.InvalidateVerificationsByEmail{
+				Email: action.Email,
+				Kind:  enum.EmailVerificationKindSignIn,
+			})
+
 			err := bus.Dispatch(c, &cmd.SaveVerificationKey{
 				Key:      action.LinkKey,
 				Code:     action.VerificationCode,
@@ -139,6 +146,12 @@ func SignInByEmailWithName() web.HandlerFunc {
 			return c.Forbidden()
 		}
 
+		// Invalidate any previous active verification codes for this email
+		_ = bus.Dispatch(c, &cmd.InvalidateVerificationsByEmail{
+			Email: action.Email,
+			Kind:  enum.EmailVerificationKindSignIn,
+		})
+
 		// Save verification with name
 		err = bus.Dispatch(c, &cmd.SaveVerificationKey{
 			Key:      action.LinkKey,
@@ -159,18 +172,19 @@ func SignInByEmailWithName() web.HandlerFunc {
 // VerifySignInCode verifies the code entered by the user and signs them in
 func VerifySignInCode() web.HandlerFunc {
 	return func(c *web.Context) error {
+		const maxAttempts = 5
+
 		action := &actions.VerifySignInCode{}
 		if result := c.BindTo(action); !result.Ok {
 			return c.HandleValidation(result)
 		}
 
-		// Get verification by email and code
-		verification := &query.GetVerificationByEmailAndCode{
+		// Look up the most recent active verification by email (without code)
+		activeVerification := &query.GetActiveVerificationByEmail{
 			Email: action.Email,
-			Code:  action.Code,
 			Kind:  enum.EmailVerificationKindSignIn,
 		}
-		err := bus.Dispatch(c, verification)
+		err := bus.Dispatch(c, activeVerification)
 		if err != nil {
 			if errors.Cause(err) == app.ErrNotFound {
 				return c.BadRequest(web.Map{
@@ -180,21 +194,31 @@ func VerifySignInCode() web.HandlerFunc {
 			return c.Failure(err)
 		}
 
-		result := verification.Result
+		result := activeVerification.Result
 
-		// Code is single-use: reject if already verified
-		if result.VerifiedAt != nil {
+		// Check if max attempts exceeded
+		if result.Attempts >= maxAttempts {
 			return c.BadRequest(web.Map{
-				"code": "Invalid or expired verification code",
+				"code": "Too many attempts. Please request a new code.",
 			})
 		}
 
-		// Check if expired
-		if time.Now().After(result.ExpiresAt) {
-			// Mark as verified to prevent reuse
-			_ = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: result.Key})
+		// Increment attempts before comparing (prevents timing attacks)
+		if err := bus.Dispatch(c, &cmd.IncrementVerificationAttempts{Key: result.Key}); err != nil {
+			return c.Failure(err)
+		}
+
+		// Compare the submitted code with the stored code
+		if result.Code != action.Code {
+			if result.Attempts+1 >= maxAttempts {
+				// Final attempt failed — invalidate the code
+				_ = bus.Dispatch(c, &cmd.SetKeyAsVerified{Key: result.Key})
+				return c.BadRequest(web.Map{
+					"code": "Too many attempts. Please request a new code.",
+				})
+			}
 			return c.BadRequest(web.Map{
-				"code": "Invalid or expired verification code",
+				"code": "Invalid or expired verification code" + fmt.Sprintf(" (attempt %d of %d)", result.Attempts+1, maxAttempts),
 			})
 		}
 
@@ -266,6 +290,12 @@ func ResendSignInCode() web.HandlerFunc {
 		if !action.IsAuthorized(c, c.User()) {
 			return c.Forbidden()
 		}
+
+		// Invalidate any previous active verification codes for this email
+		_ = bus.Dispatch(c, &cmd.InvalidateVerificationsByEmail{
+			Email: action.Email,
+			Kind:  enum.EmailVerificationKindSignIn,
+		})
 
 		// Save new verification code
 		err := bus.Dispatch(c, &cmd.SaveVerificationKey{

--- a/app/handlers/signin_test.go
+++ b/app/handlers/signin_test.go
@@ -43,6 +43,10 @@ func TestSignInByEmailHandler_ExistingUser(t *testing.T) {
 		return nil
 	})
 
+	bus.AddHandler(func(ctx context.Context, c *cmd.InvalidateVerificationsByEmail) error {
+		return nil
+	})
+
 	bus.AddHandler(func(ctx context.Context, q *query.GetUserByEmail) error {
 		if q.Email == "jon.snow@got.com" {
 			q.Result = mock.JonSnow
@@ -86,6 +90,10 @@ func TestSignInByEmailWithNameHandler_NewUser(t *testing.T) {
 	var saveKeyCmd *cmd.SaveVerificationKey
 	bus.AddHandler(func(ctx context.Context, c *cmd.SaveVerificationKey) error {
 		saveKeyCmd = c
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.InvalidateVerificationsByEmail) error {
 		return nil
 	})
 
@@ -788,7 +796,33 @@ func TestSignInPageHandler_PrivateTenant_UnauthenticatedUser(t *testing.T) {
 func TestVerifySignInCodeHandler_InvalidCode(t *testing.T) {
 	RegisterT(t)
 
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
+		q.Result = &entity.EmailVerification{
+			Email:     "jon.snow@got.com",
+			Key:       "some-long-link-key",
+			Code:      "123456",
+			CreatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(15 * time.Minute),
+		}
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
+		return nil
+	})
+
+	server := mock.NewServer()
+	code, _ := server.
+		OnTenant(mock.DemoTenant).
+		ExecutePost(handlers.VerifySignInCode(), `{ "email": "jon.snow@got.com", "code": "999999" }`)
+
+	Expect(code).Equals(http.StatusBadRequest)
+}
+
+func TestVerifySignInCodeHandler_NoActiveVerification(t *testing.T) {
+	RegisterT(t)
+
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
 		return app.ErrNotFound
 	})
 
@@ -800,41 +834,80 @@ func TestVerifySignInCodeHandler_InvalidCode(t *testing.T) {
 	Expect(code).Equals(http.StatusBadRequest)
 }
 
-func TestVerifySignInCodeHandler_ExpiredCode(t *testing.T) {
+func TestVerifySignInCodeHandler_MaxAttemptsExceeded(t *testing.T) {
 	RegisterT(t)
 
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
 		q.Result = &entity.EmailVerification{
 			Email:     "jon.snow@got.com",
-			Key:       "123456",
-			CreatedAt: time.Now().Add(-20 * time.Minute),
-			ExpiresAt: time.Now().Add(-5 * time.Minute),
+			Key:       "some-long-link-key",
+			Code:      "123456",
+			CreatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(15 * time.Minute),
+			Attempts:  5,
 		}
 		return nil
 	})
 
-	bus.AddHandler(func(ctx context.Context, c *cmd.SetKeyAsVerified) error {
-		return nil
-	})
-
 	server := mock.NewServer()
-	code, _ := server.
+	code, response := server.
 		OnTenant(mock.DemoTenant).
 		ExecutePost(handlers.VerifySignInCode(), `{ "email": "jon.snow@got.com", "code": "123456" }`)
 
 	Expect(code).Equals(http.StatusBadRequest)
+	Expect(response.Body.String()).ContainsSubstring("Too many attempts")
+}
+
+func TestVerifySignInCodeHandler_WrongCode_FinalAttempt_InvalidatesCode(t *testing.T) {
+	RegisterT(t)
+
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
+		q.Result = &entity.EmailVerification{
+			Email:     "jon.snow@got.com",
+			Key:       "some-long-link-key",
+			Code:      "123456",
+			CreatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(15 * time.Minute),
+			Attempts:  4, // This is the 5th attempt (0-indexed)
+		}
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
+		return nil
+	})
+
+	verified := false
+	bus.AddHandler(func(ctx context.Context, c *cmd.SetKeyAsVerified) error {
+		verified = true
+		return nil
+	})
+
+	server := mock.NewServer()
+	code, response := server.
+		OnTenant(mock.DemoTenant).
+		ExecutePost(handlers.VerifySignInCode(), `{ "email": "jon.snow@got.com", "code": "999999" }`)
+
+	Expect(code).Equals(http.StatusBadRequest)
+	Expect(verified).IsTrue()
+	Expect(response.Body.String()).ContainsSubstring("Too many attempts")
 }
 
 func TestVerifySignInCodeHandler_CorrectCode_ExistingUser(t *testing.T) {
 	RegisterT(t)
 
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
 		q.Result = &entity.EmailVerification{
 			Email:     "jon.snow@got.com",
-			Key:       "123456",
+			Key:       "some-long-link-key",
+			Code:      "123456",
 			CreatedAt: time.Now(),
 			ExpiresAt: time.Now().Add(15 * time.Minute),
 		}
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
 		return nil
 	})
 
@@ -859,14 +932,19 @@ func TestVerifySignInCodeHandler_CorrectCode_ExistingUser(t *testing.T) {
 func TestVerifySignInCodeHandler_CorrectCode_NewUser_WithoutName(t *testing.T) {
 	RegisterT(t)
 
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
 		q.Result = &entity.EmailVerification{
 			Email:     "new.user@got.com",
-			Key:       "123456",
+			Key:       "some-long-link-key",
+			Code:      "123456",
 			CreatedAt: time.Now(),
 			ExpiresAt: time.Now().Add(15 * time.Minute),
 			Name:      "", // No name stored (legacy flow)
 		}
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
 		return nil
 	})
 
@@ -886,14 +964,19 @@ func TestVerifySignInCodeHandler_CorrectCode_NewUser_WithoutName(t *testing.T) {
 func TestVerifySignInCodeHandler_CorrectCode_NewUser_WithName(t *testing.T) {
 	RegisterT(t)
 
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
 		q.Result = &entity.EmailVerification{
 			Email:     "new.user@got.com",
-			Key:       "123456",
+			Key:       "some-long-link-key",
+			Code:      "123456",
 			CreatedAt: time.Now(),
 			ExpiresAt: time.Now().Add(15 * time.Minute),
 			Name:      "New User", // Name stored (new flow)
 		}
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
 		return nil
 	})
 
@@ -932,13 +1015,18 @@ func TestVerifySignInCodeHandler_CorrectCode_NewUser_PrivateTenant(t *testing.T)
 	server := mock.NewServer()
 	mock.DemoTenant.IsPrivate = true
 
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
+	bus.AddHandler(func(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
 		q.Result = &entity.EmailVerification{
 			Email:     "new.user@got.com",
-			Key:       "123456",
+			Key:       "some-long-link-key",
+			Code:      "123456",
 			CreatedAt: time.Now(),
 			ExpiresAt: time.Now().Add(15 * time.Minute),
 		}
+		return nil
+	})
+
+	bus.AddHandler(func(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
 		return nil
 	})
 
@@ -953,28 +1041,10 @@ func TestVerifySignInCodeHandler_CorrectCode_NewUser_PrivateTenant(t *testing.T)
 	Expect(code).Equals(http.StatusForbidden)
 }
 
-func TestVerifySignInCodeHandler_AlreadyVerifiedCode_ShouldReject(t *testing.T) {
-	RegisterT(t)
-
-	verifiedAt := time.Now().Add(-1 * time.Minute)
-	bus.AddHandler(func(ctx context.Context, q *query.GetVerificationByEmailAndCode) error {
-		q.Result = &entity.EmailVerification{
-			Email:      "jon.snow@got.com",
-			Key:        "some-long-link-key",
-			CreatedAt:  time.Now().Add(-10 * time.Minute),
-			ExpiresAt:  time.Now().Add(5 * time.Minute),
-			VerifiedAt: &verifiedAt,
-		}
-		return nil
-	})
-
-	server := mock.NewServer()
-	code, _ := server.
-		OnTenant(mock.DemoTenant).
-		ExecutePost(handlers.VerifySignInCode(), `{ "email": "jon.snow@got.com", "code": "123456" }`)
-
-	Expect(code).Equals(http.StatusBadRequest)
-}
+// Note: AlreadyVerifiedCode test removed — the new flow uses GetActiveVerificationByEmail
+// which filters out verified records at the SQL level (verified_at IS NULL).
+// If all codes are verified, GetActiveVerificationByEmail returns ErrNotFound,
+// which is covered by TestVerifySignInCodeHandler_NoActiveVerification.
 
 func TestResendSignInCodeHandler_ValidEmail(t *testing.T) {
 	RegisterT(t)
@@ -985,12 +1055,21 @@ func TestResendSignInCodeHandler_ValidEmail(t *testing.T) {
 		return nil
 	})
 
+	invalidated := false
+	bus.AddHandler(func(ctx context.Context, c *cmd.InvalidateVerificationsByEmail) error {
+		Expect(c.Email).Equals("jon.snow@got.com")
+		Expect(c.Kind).Equals(enum.EmailVerificationKindSignIn)
+		invalidated = true
+		return nil
+	})
+
 	server := mock.NewServer()
 	code, _ := server.
 		OnTenant(mock.DemoTenant).
 		ExecutePost(handlers.ResendSignInCode(), `{ "email": "jon.snow@got.com" }`)
 
 	Expect(code).Equals(http.StatusOK)
+	Expect(invalidated).IsTrue()
 	Expect(saveKeyCmd.Key).HasLen(64)
 	Expect(saveKeyCmd.Code).HasLen(6)
 	Expect(saveKeyCmd.Request.GetKind()).Equals(enum.EmailVerificationKindSignIn)

--- a/app/models/cmd/tenant.go
+++ b/app/models/cmd/tenant.go
@@ -64,5 +64,14 @@ type SetKeyAsVerified struct {
 	Key string
 }
 
+type IncrementVerificationAttempts struct {
+	Key string
+}
+
+type InvalidateVerificationsByEmail struct {
+	Email string
+	Kind  enum.EmailVerificationKind
+}
+
 type InvalidatePreviousSignUpKeys struct {
 }

--- a/app/models/entity/email_verification.go
+++ b/app/models/entity/email_verification.go
@@ -12,11 +12,13 @@ type EmailVerification struct {
 	Email      string
 	Name       string
 	Key        string
+	Code       string
 	UserID     int
 	Kind       enum.EmailVerificationKind
 	CreatedAt  time.Time
 	ExpiresAt  time.Time
 	VerifiedAt *time.Time
+	Attempts   int
 }
 
 // GenerateEmailVerificationKey returns a 64 chars key

--- a/app/models/query/tenant.go
+++ b/app/models/query/tenant.go
@@ -36,6 +36,14 @@ type GetVerificationByEmailAndCode struct {
 	Result *entity.EmailVerification
 }
 
+type GetActiveVerificationByEmail struct {
+	Email string
+	Kind  enum.EmailVerificationKind
+
+	// Output
+	Result *entity.EmailVerification
+}
+
 type GetFirstTenant struct {
 
 	// Output

--- a/app/services/sqlstore/dbEntities/verification.go
+++ b/app/services/sqlstore/dbEntities/verification.go
@@ -13,11 +13,13 @@ type EmailVerification struct {
 	Name       string                     `db:"name"`
 	Email      string                     `db:"email"`
 	Key        string                     `db:"key"`
+	Code       dbx.NullString             `db:"code"`
 	Kind       enum.EmailVerificationKind `db:"kind"`
 	UserID     dbx.NullInt                `db:"user_id"`
 	CreatedAt  time.Time                  `db:"created_at"`
 	ExpiresAt  time.Time                  `db:"expires_at"`
 	VerifiedAt dbx.NullTime               `db:"verified_at"`
+	Attempts   int                        `db:"attempts"`
 }
 
 func (t *EmailVerification) ToModel() *entity.EmailVerification {
@@ -25,10 +27,12 @@ func (t *EmailVerification) ToModel() *entity.EmailVerification {
 		Name:       t.Name,
 		Email:      t.Email,
 		Key:        t.Key,
+		Code:       t.Code.String,
 		Kind:       t.Kind,
 		CreatedAt:  t.CreatedAt,
 		ExpiresAt:  t.ExpiresAt,
 		VerifiedAt: nil,
+		Attempts:   t.Attempts,
 	}
 
 	if t.VerifiedAt.Valid {

--- a/app/services/sqlstore/postgres/postgres.go
+++ b/app/services/sqlstore/postgres/postgres.go
@@ -118,8 +118,11 @@ func (s Service) Init() {
 
 	bus.AddHandler(getVerificationByKey)
 	bus.AddHandler(getVerificationByEmailAndCode)
+	bus.AddHandler(getActiveVerificationByEmail)
 	bus.AddHandler(saveVerificationKey)
 	bus.AddHandler(setKeyAsVerified)
+	bus.AddHandler(incrementVerificationAttempts)
+	bus.AddHandler(invalidateVerificationsByEmail)
 	bus.AddHandler(getPendingSignUpVerification)
 	bus.AddHandler(invalidatePreviousSignUpKeys)
 

--- a/app/services/sqlstore/postgres/tenant.go
+++ b/app/services/sqlstore/postgres/tenant.go
@@ -130,7 +130,7 @@ func getVerificationByKey(ctx context.Context, q *query.GetVerificationByKey) er
 	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
 		verification := dbEntities.EmailVerification{}
 
-		query := "SELECT id, email, name, key, created_at, verified_at, expires_at, kind, user_id FROM email_verifications WHERE key = $1 AND kind = $2 LIMIT 1"
+		query := "SELECT id, email, name, key, code, created_at, verified_at, expires_at, kind, user_id, attempts FROM email_verifications WHERE key = $1 AND kind = $2 LIMIT 1"
 		err := trx.Get(&verification, query, q.Key, q.Kind)
 		if err != nil {
 			return errors.Wrap(err, "failed to get email verification by its key")
@@ -145,7 +145,7 @@ func getVerificationByEmailAndCode(ctx context.Context, q *query.GetVerification
 	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
 		verification := dbEntities.EmailVerification{}
 
-		query := "SELECT id, email, name, key, created_at, verified_at, expires_at, kind, user_id FROM email_verifications WHERE tenant_id = $1 AND email = $2 AND code = $3 AND kind = $4 LIMIT 1"
+		query := "SELECT id, email, name, key, code, created_at, verified_at, expires_at, kind, user_id, attempts FROM email_verifications WHERE tenant_id = $1 AND email = $2 AND code = $3 AND kind = $4 LIMIT 1"
 		err := trx.Get(&verification, query, tenant.ID, q.Email, q.Code, q.Kind)
 		if err != nil {
 			return errors.Wrap(err, "failed to get email verification by email and code")
@@ -183,6 +183,52 @@ func setKeyAsVerified(ctx context.Context, c *cmd.SetKeyAsVerified) error {
 		_, err := trx.Execute(query, time.Now(), tenant.ID, c.Key)
 		if err != nil {
 			return errors.Wrap(err, "failed to update verified date of email verification request")
+		}
+		return nil
+	})
+}
+
+func getActiveVerificationByEmail(ctx context.Context, q *query.GetActiveVerificationByEmail) error {
+	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
+		verification := dbEntities.EmailVerification{}
+
+		query := `SELECT id, email, name, key, code, created_at, verified_at, expires_at, kind, user_id, attempts
+		          FROM email_verifications
+		          WHERE tenant_id = $1 AND email = $2 AND kind = $3
+		            AND verified_at IS NULL AND expires_at > $4
+		          ORDER BY created_at DESC
+		          LIMIT 1`
+		err := trx.Get(&verification, query, tenant.ID, q.Email, q.Kind, time.Now())
+		if err != nil {
+			return errors.Wrap(err, "failed to get active email verification by email")
+		}
+
+		q.Result = verification.ToModel()
+		return nil
+	})
+}
+
+func incrementVerificationAttempts(ctx context.Context, c *cmd.IncrementVerificationAttempts) error {
+	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
+		_, err := trx.Execute(
+			"UPDATE email_verifications SET attempts = attempts + 1 WHERE tenant_id = $1 AND key = $2",
+			tenant.ID, c.Key,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to increment verification attempts")
+		}
+		return nil
+	})
+}
+
+func invalidateVerificationsByEmail(ctx context.Context, c *cmd.InvalidateVerificationsByEmail) error {
+	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
+		_, err := trx.Execute(
+			"UPDATE email_verifications SET verified_at = $1 WHERE tenant_id = $2 AND email = $3 AND kind = $4 AND verified_at IS NULL",
+			time.Now(), tenant.ID, c.Email, c.Kind,
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to invalidate verifications for email '%s'", c.Email)
 		}
 		return nil
 	})
@@ -253,10 +299,10 @@ func getPendingSignUpVerification(ctx context.Context, q *query.GetPendingSignUp
 	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
 		verification := dbEntities.EmailVerification{}
 
-		query := `SELECT id, email, name, key, created_at, verified_at, expires_at, kind, user_id 
-		          FROM email_verifications 
+		query := `SELECT id, email, name, key, code, created_at, verified_at, expires_at, kind, user_id, attempts
+		          FROM email_verifications
 		          WHERE tenant_id = $1 AND kind = $2 AND verified_at IS NULL
-		          ORDER BY created_at DESC 
+		          ORDER BY created_at DESC
 		          LIMIT 1`
 		err := trx.Get(&verification, query, tenant.ID, enum.EmailVerificationKindSignUp)
 		if err != nil {

--- a/migrations/202605011200_add_verification_attempts.sql
+++ b/migrations/202605011200_add_verification_attempts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE email_verifications ADD COLUMN attempts SMALLINT NOT NULL DEFAULT 0;

--- a/public/components/common/SignInControl.tsx
+++ b/public/components/common/SignInControl.tsx
@@ -32,6 +32,7 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
   const [code, setCode] = useState("")
   const [error, setError] = useState<Failure | undefined>(undefined)
   const [resendMessage, setResendMessage] = useState("")
+  const [lockedOut, setLockedOut] = useState(false)
 
   const forceShowEmailForm = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
@@ -99,6 +100,12 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
       // Handle validation errors - convert data object to Failure format
       const data = result.data as Record<string, string> | undefined
       if (data && typeof data === "object") {
+        // Check if locked out due to too many attempts
+        if (data.code && data.code.includes("Too many attempts")) {
+          setLockedOut(true)
+          setError(undefined)
+          return
+        }
         const errors = Object.entries(data).map(([field, message]) => ({
           field,
           message,
@@ -117,6 +124,7 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
     if (result.ok) {
       setError(undefined)
       setCode("")
+      setLockedOut(false)
       setResendMessage(i18n._({ id: "signin.code.sent", message: "A new code has been sent to your email." }))
     } else if (result.error) {
       setError(result.error)
@@ -127,6 +135,7 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
 
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setResendMessage("")
     // Form submission handler that routes to the correct function based on step
     if (emailSignInStep === EmailSigninStep.EnterEmail) {
       await signIn()
@@ -153,6 +162,7 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
       )
     }
     if (emailSignInStep === EmailSigninStep.EnterCode) {
+      if (lockedOut) return null
       return (
         <Button className="w-full justify-center" type="submit" variant="primary" disabled={code.length !== 6}>
           <Trans id="action.submit">Submit</Trans>
@@ -251,8 +261,25 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
   }
 
   function renderCodeField(): React.ReactNode {
+    if (lockedOut) {
+      return (
+        <>
+          <p className="text-muted mb-2 text-left">
+            <Trans id="signin.code.locked">Your code has expired due to too many incorrect attempts. Please request a new one.</Trans>
+          </p>
+          {resendMessage && <p className="text-green-700 mt-2">{resendMessage}</p>}
+          <div className="pt-3">
+            <Button className="w-full justify-center" variant="primary" onClick={resendCode}>
+              <Trans id="signin.code.getnew">Get a new code</Trans>
+            </Button>
+          </div>
+        </>
+      )
+    }
+
     return (
       <>
+        {resendMessage && <p className="text-green-700 mb-2">{resendMessage}</p>}
         <p className="text-muted mb-2 text-left">
           <Trans id="signin.code.instruction">
             Please type in the code we just sent to <strong>{email}</strong>
@@ -279,7 +306,6 @@ export const SignInControl: React.FunctionComponent<SignInControlProps> = (props
           placeholder={i18n._({ id: "signin.code.placeholder", message: "Type in the code here" })}
           maxLength={6}
         />
-        {resendMessage && <p className="text-green-700 mt-2">{resendMessage}</p>}
         <p className="text-center mt-2 text-muted text-left">
           <a
             href="#"


### PR DESCRIPTION
Adds per-record attempt counter (max 5 tries) to prevent brute-force attacks on 6-digit sign-in OTP codes (FID-Q125-02). Invalidates previous verification codes when a new code is requested. Frontend shows a clear locked-out state after max attempts are exceeded.