### PR TITLE
fix(react-ssr): JSON-encode URL when invoking ssrRender

### DIFF
--- a/app/pkg/web/react.go
+++ b/app/pkg/web/react.go
@@ -70,7 +70,12 @@ func (r *ReactRenderer) Render(u *url.URL, props Map) (string, error) {
 		return "", errors.Wrap(err, "failed to marshal props")
 	}
 
-	renderCmd := fmt.Sprintf(`ssrRender("%s", %s)`, u.String(), string(jsonArg))
+	urlArg, err := json.Marshal(u.String())
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal url")
+	}
+
+	renderCmd := fmt.Sprintf(`ssrRender(%s, %s)`, string(urlArg), string(jsonArg))
 	val, err := v8ctx.RunScript(renderCmd, r.scriptPath)
 	if err != nil {
 		if jsErr, ok := err.(*v8go.JSError); ok {

--- a/app/pkg/web/react_test.go
+++ b/app/pkg/web/react_test.go
@@ -2,6 +2,7 @@ package web_test
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/getfider/fider/app/models/entity"
@@ -58,6 +59,41 @@ func TestReactRenderer_RenderEmptyHomeHTML(t *testing.T) {
 	Expect(html).ContainsSubstring(`No posts have been created yet.`)
 	Expect(html).ContainsSubstring(`Powered by Fider`)
 	Expect(err).IsNil()
+}
+
+func TestReactRenderer_RenderWithMaliciousURL(t *testing.T) {
+	RegisterT(t)
+
+	r, err := web.NewReactRenderer("ssr.js")
+	Expect(err).IsNil()
+
+	// Attempt to break out of the JS string literal and inject code via the URL.
+	// The URL contains a literal double-quote followed by JS that would, if interpolated
+	// unsafely, execute server-side and emit attacker-controlled content into the SSR
+	// output. After the fix the URL must be JSON-encoded into the ssrRender call so the
+	// injection becomes inert.
+	u := &url.URL{
+		Scheme:   "https",
+		Host:     "demo.test.fider.io",
+		Path:     "/",
+		RawQuery: `q=",{"page":"Error/Error404.page","settings":{},"tenant":{"locale":"en"}});` + "`<h1>RCE-PROOF</h1>`" + `//`,
+	}
+	html, err := r.Render(u, web.Map{
+		"page": "Home/Home.page",
+		"tenant": &entity.Tenant{
+			Locale: "en",
+		},
+		"settings": web.Map{
+			"locale": "en",
+		},
+		"props": web.Map{
+			"posts":          make([]web.Map, 0),
+			"tags":           make([]web.Map, 0),
+			"countPerStatus": web.Map{},
+		},
+	})
+	Expect(err).IsNil()
+	Expect(strings.Contains(html, `<h1>RCE-PROOF</h1>`)).IsFalse()
 }
 
 func TestReactRenderer_RenderEmptyHomeHTML_Portuguese(t *testing.T) {


### PR DESCRIPTION
## Summary
- The SSR renderer interpolated the raw request URL into a JavaScript expression with `fmt.Sprintf` before handing it to v8go, which let a crafted query string break out of the JS string literal.
- Marshal the URL through `encoding/json` so it is emitted as a properly escaped JS string literal.

## Test plan
- [x] `godotenv -f .test.env go test ./app/pkg/web -race -short -run TestReactRenderer` (includes new `TestReactRenderer_RenderWithMaliciousURL` regression test)
- [x] `make lint-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)