### PR TITLE
fix(comments): unify create + edit limit at 2000 chars (#1535)

### DIFF
--- a/app/actions/post.go
+++ b/app/actions/post.go
@@ -221,8 +221,8 @@ func (action *AddNewComment) Validate(ctx context.Context, user *entity.User) *v
 
 	if action.Content == "" {
 		result.AddFieldFailure("content", propertyIsRequired(ctx, "comment"))
-	} else if len(action.Content) > 4000 {
-		result.AddFieldFailure("content", propertyMaxStringLen(ctx, "comment", 4000))
+	} else if len(action.Content) > 2000 {
+		result.AddFieldFailure("content", propertyMaxStringLen(ctx, "comment", 2000))
 	}
 
 	messages, err := validate.MultiImageUpload(ctx, nil, action.Attachments, validate.MultiImageUploadOpts{

--- a/app/actions/post_test.go
+++ b/app/actions/post_test.go
@@ -138,7 +138,7 @@ func TestDeleteComment(t *testing.T) {
 func TestAddNewComment_TooLongContent(t *testing.T) {
 	RegisterT(t)
 
-	action := &actions.AddNewComment{Content: strings.Repeat("a", 4001)}
+	action := &actions.AddNewComment{Content: strings.Repeat("a", 2001)}
 	result := action.Validate(context.Background(), nil)
 	ExpectFailed(result, "content")
 }
@@ -146,7 +146,7 @@ func TestAddNewComment_TooLongContent(t *testing.T) {
 func TestAddNewComment_AtMaxLength(t *testing.T) {
 	RegisterT(t)
 
-	action := &actions.AddNewComment{Content: strings.Repeat("a", 4000)}
+	action := &actions.AddNewComment{Content: strings.Repeat("a", 2000)}
 	result := action.Validate(context.Background(), nil)
 	ExpectSuccess(result)
 }
@@ -154,7 +154,7 @@ func TestAddNewComment_AtMaxLength(t *testing.T) {
 func TestEditComment_TooLongContent(t *testing.T) {
 	RegisterT(t)
 
-	action := &actions.EditComment{Content: strings.Repeat("a", 4001)}
+	action := &actions.EditComment{Content: strings.Repeat("a", 2001)}
 	result := action.Validate(context.Background(), nil)
 	ExpectFailed(result, "content")
 }

--- a/public/components/common/form/CommentEditor.tsx
+++ b/public/components/common/form/CommentEditor.tsx
@@ -240,7 +240,7 @@ interface CommentEditorProps {
   maxLength?: number
 }
 
-const DEFAULT_MAX_LENGTH = 4000
+const DEFAULT_MAX_LENGTH = 2000
 
 const Tiptap: React.FunctionComponent<CommentEditorProps> = (props) => {
   const maxLength = props.maxLength ?? DEFAULT_MAX_LENGTH

--- a/public/pages/ShowPost/components/CommentInput.tsx
+++ b/public/pages/ShowPost/components/CommentInput.tsx
@@ -27,7 +27,7 @@ export const CommentInput = (props: CommentInputProps) => {
     return cache.session.get(getCacheKey(CACHE_TITLE_KEY))
   }
 
-  const COMMENT_MAX_LENGTH = 4000
+  const COMMENT_MAX_LENGTH = 2000
 
   const fider = useFider()
   const [isSignInModalOpen, setIsSignInModalOpen] = useState(false)

--- a/public/pages/ShowPost/components/ShowComment.tsx
+++ b/public/pages/ShowPost/components/ShowComment.tsx
@@ -227,7 +227,7 @@ export const ShowComment = (props: ShowCommentProps) => {
                   placeholder={comment.content}
                   maxAttachments={2}
                   maxImageSizeKB={5 * 1024}
-                  maxLength={4000}
+                  maxLength={2000}
                   onGetImageSrc={getImageSrc}
                   onImageUploaded={handleImageUploaded}
                 />


### PR DESCRIPTION
## Summary
- Unifies the comment character limit at **2000** for both create and edit paths. The prior commit on main set `AddNewComment` to 4000 and `EditComment` to 2000, which would silently block users from editing comments they were allowed to post.
- Updates the matching frontend constants (`DEFAULT_MAX_LENGTH` in `CommentEditor`, `COMMENT_MAX_LENGTH` in `CommentInput`, the explicit `2000` passed in `ShowComment`) so the live counter, disabled-submit gating, and backend rejection all agree.
- Adjusts the comment validation tests to the new boundary.

Addresses GitHub issue #1535 (no character limit on comments enables spam).

## Test plan
- [ ] `make lint` clean
- [ ] `godotenv -f .test.env go test ./app/actions` passes (incl. `TestAddNewComment_TooLongContent`, `TestAddNewComment_AtMaxLength`, `TestEditComment_TooLongContent`)
- [ ] `make watch`: open a post, paste 2001 chars into the comment editor — counter goes red at the limit, Post button disables
- [ ] Backspace to 2000 — Post enables, submit succeeds
- [ ] Edit an existing comment past 2000 chars — Save disables; counter red
- [ ] Switch to markdown mode — textarea hard-caps at 2000 chars natively
- [ ] Force-bypass via DevTools — backend returns 400 with i18n error on `content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)