### PR TITLE
fix(comments): raise edit limit to 4000 to match create (#1535)

### DIFF
--- a/app/actions/post.go
+++ b/app/actions/post.go
@@ -348,8 +348,8 @@ func (action *EditComment) Validate(ctx context.Context, user *entity.User) *val
 
 	if action.Content == "" {
 		result.AddFieldFailure("content", propertyIsRequired(ctx, "comment"))
-	} else if len(action.Content) > 2000 {
-		result.AddFieldFailure("content", propertyMaxStringLen(ctx, "comment", 2000))
+	} else if len(action.Content) > 4000 {
+		result.AddFieldFailure("content", propertyMaxStringLen(ctx, "comment", 4000))
 	}
 
 	if len(action.Attachments) > 0 {

--- a/app/actions/post_test.go
+++ b/app/actions/post_test.go
@@ -158,3 +158,11 @@ func TestEditComment_TooLongContent(t *testing.T) {
 	result := action.Validate(context.Background(), nil)
 	ExpectFailed(result, "content")
 }
+
+func TestEditComment_AtMaxLength(t *testing.T) {
+	RegisterT(t)
+
+	action := &actions.EditComment{Content: strings.Repeat("a", 4000)}
+	result := action.Validate(context.Background(), nil)
+	ExpectSuccess(result)
+}

--- a/public/pages/ShowPost/components/ShowComment.tsx
+++ b/public/pages/ShowPost/components/ShowComment.tsx
@@ -232,7 +232,7 @@ export const ShowComment = (props: ShowCommentProps) => {
                   onImageUploaded={handleImageUploaded}
                 />
                 <div className="mt-2">
-                  <Button size="small" onClick={saveEdit} variant="primary" disabled={newContent.length > 2000}>
+                  <Button size="small" onClick={saveEdit} variant="primary" disabled={newContent.length > 4000}>
                     <Trans id="action.save">Save</Trans>
                   </Button>
                   <Button variant="tertiary" size="small" onClick={cancelEdit}>


### PR DESCRIPTION
## Summary
- `EditComment.Validate` rejected content over **2000** chars while `AddNewComment.Validate` allowed up to **4000**, so a user could post a comment but be blocked from editing their own. Aligns the edit cap to 4000.
- Matches the frontend save-button gating in `ShowComment` (`newContent.length > 4000`) — `maxLength={4000}` was already correct.
- Adds `TestEditComment_AtMaxLength` so the boundary is covered the same way `TestAddNewComment_AtMaxLength` covers create.

Followup to #1535 (initial 4000-char create cap landed in 8295d102).

## Test plan
- [ ] `make lint` clean
- [ ] `godotenv -f .test.env go test ./app/actions -run 'TestAddNewComment|TestEditComment' -v` — all 4 tests pass
- [ ] `make watch`: edit an existing comment, paste in 4001 chars → counter goes red, Save button disables
- [ ] Backspace to 4000 → Save enables, submit succeeds
- [ ] Verify create flow still accepts up to 4000 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)