### PR TITLE
fix: cascade purge attachments, comments, and votes when post/comment is deleted

### DIFF
--- a/app/services/sqlstore/postgres/comment.go
+++ b/app/services/sqlstore/postgres/comment.go
@@ -87,6 +87,15 @@ func deleteComment(ctx context.Context, c *cmd.DeleteComment) error {
 		); err != nil {
 			return errors.Wrap(err, "failed delete comment")
 		}
+
+		// Delete attachments associated with this comment
+		if _, err := trx.Execute(
+			"DELETE FROM attachments WHERE comment_id = $1 AND tenant_id = $2",
+			c.CommentID, tenant.ID,
+		); err != nil {
+			return errors.Wrap(err, "failed to delete comment attachments")
+		}
+
 		return nil
 	})
 }

--- a/app/services/sqlstore/postgres/post.go
+++ b/app/services/sqlstore/postgres/post.go
@@ -157,6 +157,36 @@ func setPostResponse(ctx context.Context, c *cmd.SetPostResponse) error {
 			return errors.Wrap(err, "failed to update post's response")
 		}
 
+		// When a post is deleted, purge associated data
+		if c.Status == enum.PostDeleted {
+			// Soft-delete all comments on this post
+			_, err = trx.Execute(`
+				UPDATE comments SET deleted_at = $1, deleted_by_id = $2
+				WHERE post_id = $3 AND tenant_id = $4 AND deleted_at IS NULL
+			`, respondedAt, user.ID, c.Post.ID, tenant.ID)
+			if err != nil {
+				return errors.Wrap(err, "failed to soft-delete comments for deleted post")
+			}
+
+			// Delete all attachments related to this post (both post-level and comment-level)
+			_, err = trx.Execute(`
+				DELETE FROM attachments
+				WHERE post_id = $1 AND tenant_id = $2
+			`, c.Post.ID, tenant.ID)
+			if err != nil {
+				return errors.Wrap(err, "failed to delete attachments for deleted post")
+			}
+
+			// Delete all votes for this post
+			_, err = trx.Execute(`
+				DELETE FROM post_votes
+				WHERE post_id = $1 AND tenant_id = $2
+			`, c.Post.ID, tenant.ID)
+			if err != nil {
+				return errors.Wrap(err, "failed to delete votes for deleted post")
+			}
+		}
+
 		c.Post.Status = c.Status
 		c.Post.Response = &entity.PostResponse{
 			Text:        c.Text,


### PR DESCRIPTION
## Problem

When a post is deleted from the WebUI (via setPostResponse with PostDeleted status), associated data is left orphaned in the database:

- **Attachments** (post-level and comment-level) are not purged
- **Comments** remain without deleted_at being set
- **Post votes** (post_votes) are not cleaned up
- **Comment attachments** are not cleaned up when individual comments are deleted

This causes the database to grow over time with unlinked data. Affected tables: ttachments, comments, post_votes, and indirectly lobs.

Fixes #1149

## Changes

### post.go - setPostResponse
When status changes to PostDeleted, added cascade cleanup:
1. Soft-delete all comments on the post (SET deleted_at)
2. Delete all attachments for the post (both post and comment-level)
3. Delete all votes for the post

### comment.go - deleteComment  
When a comment is soft-deleted, also delete its associated attachments.

## Testing

- [x] Existing post/comment attachment tests pass
- [x] Manual verification: after post deletion, ttachments, comments, and post_votes are properly cleaned up