### PR TITLE
fix(security): scope invite token verification to tenant

### DIFF
--- a/app/services/sqlstore/postgres/tenant.go
+++ b/app/services/sqlstore/postgres/tenant.go
@@ -130,8 +130,8 @@ func getVerificationByKey(ctx context.Context, q *query.GetVerificationByKey) er
 	return using(ctx, func(trx *dbx.Trx, tenant *entity.Tenant, user *entity.User) error {
 		verification := dbEntities.EmailVerification{}
 
-		query := "SELECT id, email, name, key, code, created_at, verified_at, expires_at, kind, user_id, attempts FROM email_verifications WHERE key = $1 AND kind = $2 LIMIT 1"
-		err := trx.Get(&verification, query, q.Key, q.Kind)
+		query := "SELECT id, email, name, key, code, created_at, verified_at, expires_at, kind, user_id, attempts FROM email_verifications WHERE key = $1 AND kind = $2 AND tenant_id = $3 LIMIT 1"
+		err := trx.Get(&verification, query, q.Key, q.Kind, tenant.ID)
 		if err != nil {
 			return errors.Wrap(err, "failed to get email verification by its key")
 		}

--- a/app/services/sqlstore/postgres/tenant_test.go
+++ b/app/services/sqlstore/postgres/tenant_test.go
@@ -316,6 +316,34 @@ func TestTenantStorage_SaveFindSet_ChangeEmailVerificationKey(t *testing.T) {
 	Expect(getKey.Result.ExpiresAt).TemporarilySimilar(getKey.Result.CreatedAt.Add(15*time.Minute), 1*time.Second)
 }
 
+func TestTenantStorage_VerificationKey_IsTenantScoped(t *testing.T) {
+	SetupDatabaseTest(t)
+	defer TeardownDatabaseTest()
+
+	//Save new Key on the demo tenant
+	err := bus.Dispatch(demoTenantCtx, &cmd.SaveVerificationKey{
+		Key:      "s3cr3tk3y",
+		Duration: 15 * time.Minute,
+		Request: &actions.CreateTenant{
+			Email: "jon.snow@got.com",
+			Name:  "Jon Snow",
+		},
+	})
+	Expect(err).IsNil()
+
+	//Same key must NOT be retrievable from a different tenant
+	getKeyFromOtherTenant := &query.GetVerificationByKey{Kind: enum.EmailVerificationKindSignUp, Key: "s3cr3tk3y"}
+	err = bus.Dispatch(avengersTenantCtx, getKeyFromOtherTenant)
+	Expect(errors.Cause(err)).Equals(app.ErrNotFound)
+	Expect(getKeyFromOtherTenant.Result).IsNil()
+
+	//But it is retrievable from the tenant it belongs to
+	getKey := &query.GetVerificationByKey{Kind: enum.EmailVerificationKindSignUp, Key: "s3cr3tk3y"}
+	err = bus.Dispatch(demoTenantCtx, getKey)
+	Expect(err).IsNil()
+	Expect(getKey.Result.Email).Equals("jon.snow@got.com")
+}
+
 func TestTenantStorage_FindUnknownVerificationKey(t *testing.T) {
 	SetupDatabaseTest(t)
 	defer TeardownDatabaseTest()


### PR DESCRIPTION
## Summary

Fixes a cross-tenant invitation token vulnerability (IDOR / CWE-639) reported by Doyensec.

In a multi-tenant Fider deployment, `getVerificationByKey` looked up email verification tokens by `key` + `kind` only, never checking which tenant the token belonged to. As a result, an invite token issued for tenant A could be redeemed on tenant B's subdomain, granting the attacker Member-level access to tenant B.

## Fix

`app/services/sqlstore/postgres/tenant.go` — added `AND tenant_id = $3` to the lookup query and passed the request-context `tenant.ID`. This mirrors the sibling `getVerificationByEmailAndCode`, which already scopes by tenant. A token that doesn't belong to the redeeming tenant now returns `ErrNotFound`, rejecting the redemption.

```go
query := "SELECT ... FROM email_verifications WHERE key = $1 AND kind = $2 AND tenant_id = $3 LIMIT 1"
err := trx.Get(&verification, query, q.Key, q.Kind, tenant.ID)
```

This is safe for the legitimate signup/signin/change-email flows, which always create and redeem tokens within the same tenant context (the email links point to that tenant's subdomain).

## Regression test

`TestTenantStorage_VerificationKey_IsTenantScoped` saves a key on the demo tenant, asserts it is **not** retrievable from another tenant (`ErrNotFound`), and confirms it still works from its own tenant.

## Verification

- `make build` — succeeds
- `make test` — all Go + Jest tests pass (incl. the new test)
- `make lint` — 0 Go issues (2 pre-existing unrelated ESLint warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)