### PR TITLE
fix(oauth): block SSRF via custom provider Token/Profile URLs

### DIFF
--- a/app/services/oauth/oauth.go
+++ b/app/services/oauth/oauth.go
@@ -315,6 +315,11 @@ func getOAuthRawProfile(ctx context.Context, q *query.GetOAuthRawProfile) error 
 		return err
 	}
 
+	// Guard against SSRF: TokenURL triggers a server-side request during the token exchange.
+	if msgs := validate.WebhookURL(config.TokenURL); len(msgs) > 0 {
+		return errors.New("Token URL is not allowed: %s", strings.Join(msgs, "; "))
+	}
+
 	oauthBaseURL := web.OAuthBaseURL(ctx)
 	exchange := (&oauth2.Config{
 		ClientID:     config.ClientID,
@@ -340,6 +345,11 @@ func getOAuthRawProfile(ctx context.Context, q *query.GetOAuthRawProfile) error 
 		body, _ := base64.RawURLEncoding.DecodeString(parts[1])
 		q.Result = string(body)
 		return nil
+	}
+
+	// Guard against SSRF: ProfileURL is user-configurable and fetched server-side.
+	if msgs := validate.WebhookURL(config.ProfileURL); len(msgs) > 0 {
+		return errors.New("Profile URL is not allowed: %s", strings.Join(msgs, "; "))
 	}
 
 	req := &cmd.HTTPRequest{

--- a/app/services/oauth/oauth_test.go
+++ b/app/services/oauth/oauth_test.go
@@ -668,3 +668,31 @@ func TestParseOAuthRawProfile_InvalidInputs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOAuthRawProfile_BlocksInternalTokenURL(t *testing.T) {
+	RegisterT(t)
+	bus.Init(&oauth.Service{})
+
+	// Custom provider whose TokenURL targets an internal/link-local address.
+	bus.AddHandler(func(ctx context.Context, q *query.GetCustomOAuthConfigByProvider) error {
+		q.Result = &entity.OAuthConfig{
+			Provider:       q.Provider,
+			Status:         enum.OAuthConfigEnabled,
+			ClientID:       "client",
+			ClientSecret:   "secret",
+			AuthorizeURL:   "https://example.org/authorize",
+			TokenURL:       "http://169.254.169.254/latest/api/token",
+			ProfileURL:     "https://example.org/profile",
+			JSONUserIDPath: "id",
+		}
+		return nil
+	})
+
+	ctx := newGetContext("http://login.test.fider.io:3000")
+	rawProfile := &query.GetOAuthRawProfile{Provider: "_test1", Code: "any-code"}
+
+	// The SSRF guard must reject before any server-side request (no token exchange happens).
+	err := bus.Dispatch(ctx, rawProfile)
+	Expect(err).IsNotNil()
+	Expect(rawProfile.Result).Equals("")
+}


### PR DESCRIPTION
## Summary

Fixes a **High-severity SSRF** (Doyensec advisory — *SSRF via OAuth Profile URL*). A tenant administrator configuring a custom OAuth provider can set `TokenURL` and `ProfileURL`, which Fider fetches **server-side** during the OAuth flow. The admin "test" flow (`/oauth/:provider/echo`) echoes the response body straight back, so these URLs could be pointed at internal hosts (cloud metadata endpoints, MailHog, etc.) to exfiltrate internal responses.

Previously these fields were only **format-validated** (`validate.URL` → `url.ParseRequestURI`), with no check against private/internal addresses.

## Fix

Apply the project's existing `validate.WebhookURL()` guard (blocks loopback / private / link-local / unspecified / `localhost`) **at request time** in `getOAuthRawProfile`:

- before the token exchange (`TokenURL`)
- before the profile fetch (`ProfileURL`)

This mirrors exactly how outbound **webhooks** are already protected (`app/services/webhook/webhook.go`). Request-time placement (vs. save-time) closes the DNS-rebinding / TOCTTOU window the advisory calls out. Built-in providers (Google/GitHub/Facebook) resolve to public IPs and are unaffected.

`AuthorizeURL` is intentionally left unguarded — it is only built into a browser redirect, never fetched server-side, so it is not an SSRF vector.

## Notes

- Like webhooks, this blocks custom providers pointed at `localhost`/private IPs in **all** environments (e.g. local mock-OAuth servers). No env escape hatch, kept consistent with the webhook precedent.

## Testing

- Added `TestGetOAuthRawProfile_BlocksInternalTokenURL` (network-free, uses literal `169.254.169.254`).
- Run: `godotenv -f .test.env go test ./app/services/oauth/ -run TestGetOAuthRawProfile_BlocksInternalTokenURL -short -v`
- Manual: custom provider with `Profile URL = http://localhost:8025/...` → the OAuth test page now shows *"Profile URL is not allowed: …"* instead of the internal response body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
