### PR TITLE
feat(post-status): add Review status between Open and Planned

### DIFF
--- a/app/actions/post.go
+++ b/app/actions/post.go
@@ -257,7 +257,9 @@ func (action *SetResponse) IsAuthorized(ctx context.Context, user *entity.User) 
 func (action *SetResponse) Validate(ctx context.Context, user *entity.User) *validate.Result {
 	result := validate.Success()
 
-	if action.Status < enum.PostOpen || action.Status > enum.PostDuplicate {
+	// Only known statuses are settable via this action. PostDeleted is reserved
+	// for the deletion flow, never set through SetResponse.
+	if action.Status == enum.PostDeleted || action.Status.Name() == "unknown" {
 		result.AddFieldFailure("status", propertyIsInvalid(ctx, "status"))
 	}
 

--- a/app/actions/post_test.go
+++ b/app/actions/post_test.go
@@ -68,6 +68,17 @@ func TestSetResponse_InvalidStatus(t *testing.T) {
 	ExpectFailed(result, "status")
 }
 
+func TestSetResponse_ReviewIsValid(t *testing.T) {
+	RegisterT(t)
+
+	action := &actions.SetResponse{
+		Status: enum.PostReview,
+		Text:   "Triaging — need product input before planning",
+	}
+	result := action.Validate(context.Background(), nil)
+	ExpectSuccess(result)
+}
+
 func TestDeletePost_WhenIsBeingReferenced(t *testing.T) {
 	RegisterT(t)
 

--- a/app/models/enum/post_status.go
+++ b/app/models/enum/post_status.go
@@ -18,6 +18,8 @@ var (
 	PostDuplicate PostStatus = 5
 	//PostDeleted is used when the post is completely removed from the site and should never be shown again
 	PostDeleted PostStatus = 6
+	//PostReview is used when an open post is being evaluated before being planned (triage state)
+	PostReview PostStatus = 7
 )
 var postStatusIDs = map[PostStatus]string{
 	PostOpen:      "open",
@@ -27,6 +29,7 @@ var postStatusIDs = map[PostStatus]string{
 	PostPlanned:   "planned",
 	PostDuplicate: "duplicate",
 	PostDeleted:   "deleted",
+	PostReview:    "review",
 }
 
 var postStatusNames = map[string]PostStatus{
@@ -37,6 +40,7 @@ var postStatusNames = map[string]PostStatus{
 	"planned":   PostPlanned,
 	"duplicate": PostDuplicate,
 	"deleted":   PostDeleted,
+	"review":    PostReview,
 }
 
 // MarshalText returns the Text version of the post status

--- a/app/services/sqlstore/postgres/common.go
+++ b/app/services/sqlstore/postgres/common.go
@@ -46,6 +46,7 @@ func getViewData(query query.SearchPosts, tagsPlaceholder int) (string, []enum.P
 		// Use a sensible default list of status filters
 		statusFilters = []enum.PostStatus{
 			enum.PostOpen,
+			enum.PostReview,
 			enum.PostStarted,
 			enum.PostPlanned,
 		}
@@ -86,6 +87,7 @@ func getViewData(query query.SearchPosts, tagsPlaceholder int) (string, []enum.P
 		sort = "id"
 		statusFilters = []enum.PostStatus{
 			enum.PostOpen,
+			enum.PostReview,
 			enum.PostStarted,
 			enum.PostPlanned,
 			enum.PostCompleted,

--- a/locale/en/client.json
+++ b/locale/en/client.json
@@ -29,6 +29,7 @@
   "enum.poststatus.duplicate": "Duplicate",
   "enum.poststatus.open": "Open",
   "enum.poststatus.planned": "Planned",
+  "enum.poststatus.review": "Review",
   "enum.poststatus.started": "Started",
   "error.accessdenied.contact": "If you believe this is an error, please contact your administrator.",
   "error.accessdenied.text": "You do not have the required permissions to access this site.",

--- a/locale/en/server.json
+++ b/locale/en/server.json
@@ -31,6 +31,7 @@
   "validation.custom.maximagesize": "The image size must be smaller than {kilobytes}KB.",
   "validation.custom.invalidemoji": "Invalid reaction emoji.",
   "enum.poststatus.open": "Open",
+  "enum.poststatus.review": "Review",
   "enum.poststatus.started": "Started",
   "enum.poststatus.completed": "Completed",
   "enum.poststatus.declined": "Declined",

--- a/public/components/ShowPostResponse.tsx
+++ b/public/components/ShowPostResponse.tsx
@@ -7,6 +7,7 @@ import HeroIconSparkles from "@fider/assets/images/heroicons-sparkles-outline.sv
 import HeroIconLightBulb from "@fider/assets/images/heroicons-lightbulb.svg"
 import HeroIconThumbsUp from "@fider/assets/images/heroicons-thumbsup.svg"
 import HeroIconThumbsDown from "@fider/assets/images/heroicons-thumbsdown.svg"
+import HeroIconEye from "@fider/assets/images/heroicons-eye.svg"
 import { HStack, VStack } from "./layout"
 import { Trans } from "@lingui/react/macro"
 import { useFider } from "@fider/hooks"
@@ -72,6 +73,8 @@ const getLozengeProps = (status: PostStatus): { icon: SpriteSymbol; bg: string; 
       return { icon: HeroIconThumbsUp, bg: "bg-blue-100", color: "text-blue-700", border: "border-blue-400" }
     case PostStatus.Started:
       return { icon: HeroIconSparkles, bg: "bg-blue-100", color: "text-blue-700", border: "border-blue-400" }
+    case PostStatus.Review:
+      return { icon: HeroIconEye, bg: "bg-blue-100", color: "text-blue-700", border: "border-blue-400" }
     case PostStatus.Open:
       return { icon: HeroIconLightBulb, bg: "bg-blue-100", color: "text-blue-700", border: "border-blue-400" }
     default:
@@ -83,6 +86,8 @@ const getStatusTranslation = (status: PostStatus): JSX.Element => {
   switch (status) {
     case PostStatus.Open:
       return <Trans id="enum.poststatus.open">Open</Trans>
+    case PostStatus.Review:
+      return <Trans id="enum.poststatus.review">Review</Trans>
     case PostStatus.Planned:
       return <Trans id="enum.poststatus.planned">Planned</Trans>
     case PostStatus.Started:

--- a/public/models/post.ts
+++ b/public/models/post.ts
@@ -21,6 +21,7 @@ export class PostStatus {
   constructor(public title: string, public value: string, public show: boolean, public closed: boolean, public filterable: boolean) {}
 
   public static Open = new PostStatus("Open", "open", false, false, true)
+  public static Review = new PostStatus("Review", "review", true, false, true)
   public static Planned = new PostStatus("Planned", "planned", true, false, true)
   public static Started = new PostStatus("Started", "started", true, false, true)
   public static Completed = new PostStatus("Completed", "completed", true, true, true)
@@ -37,7 +38,7 @@ export class PostStatus {
     throw new Error(`PostStatus not found for value ${value}.`)
   }
 
-  public static All = [PostStatus.Open, PostStatus.Planned, PostStatus.Started, PostStatus.Completed, PostStatus.Duplicate, PostStatus.Declined]
+  public static All = [PostStatus.Open, PostStatus.Review, PostStatus.Planned, PostStatus.Started, PostStatus.Completed, PostStatus.Duplicate, PostStatus.Declined]
 }
 
 export interface PostResponse {


### PR DESCRIPTION
Adds a new built-in post status "Review" for the triage step where an Open post is being evaluated before being accepted onto the roadmap (Planned). Same blue lozenge family as the other in-lifecycle statuses (Open/Planned/Started); distinct icon (eye) so the bubble reads unambiguously.

Changes:
- enum.PostReview = 7 added to the Go enum, registered in both name<->ID maps.
- SetResponse validation tightened to allowlist-by-name: any unknown status string and PostDeleted (reserved for deletion) are rejected; Review now passes. Replaces the prior numeric range check.
- Postgres default-view filter and "all" view filter include Review so triaged posts show alongside Open/Started/Planned.
- TypeScript PostStatus mirror gets the new Review constant and is inserted into PostStatus.All in workflow order (Open -> Review -> Planned -> Started -> Completed -> Duplicate -> Declined).
- ShowPostResponse lozenge: HeroIconEye + same blue swatch as the other open-lifecycle statuses; Trans key for the translated label.
- locale/en client + server: "Review" translation.
- New test TestSetResponse_ReviewIsValid; the existing TestSetResponse_InvalidStatus (PostDeleted) still passes via the allowlist check.

Use case: organizations that want a triage step ("is this worth making a project?") before promoting an Open idea onto a roadmap. The new status is fully optional - existing posts default to Open and no migration of in-flight posts is required.

**Issue:** <!-- What's this PR for? Link it to a GitHub issue or create one before you submit this Pull Request. -->

<!-- Briefly explain what is being changed with this Pull Request. -->
