### PR TITLE
Stabilize lockfile against Dependabot optional-peer pruning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "sass-loader": "12.6.0",
         "svg-sprite-loader": "6.0.11",
         "svgo-loader": "3.0.0",
+        "ts-node": "^10.9.2",
         "typescript": "4.6.4",
         "webpack": "5.105.4",
         "webpack-bundle-analyzer": "4.5.0",
@@ -5156,36 +5157,28 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -6274,9 +6267,7 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -7546,9 +7537,7 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -13971,9 +13960,7 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -18459,8 +18446,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18505,8 +18490,6 @@
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -19050,9 +19033,7 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -19715,8 +19696,6 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -72,10 +72,16 @@
     "sass-loader": "12.6.0",
     "svg-sprite-loader": "6.0.11",
     "svgo-loader": "3.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "4.6.4",
     "webpack": "5.105.4",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.2"
+  },
+  "overrides": {
+    "@lingui/conf": {
+      "typescript": "5.9.3"
+    }
   },
   "browserslist": ">1%, not dead",
   "jest": {


### PR DESCRIPTION
## Problem

Every JS Dependabot PR fails CI for the same reason: Dependabot regenerates `package-lock.json` with a resolver that **prunes optional peer dependencies** the build/tests rely on, producing a lockfile that fails CI:

- **`npm ci`** (test-ui / test-server / build) fails with `Missing: typescript@X from lock file` — the `@lingui/conf` → `cosmiconfig` *optional-peer* typescript, whose version also churned between `5.9.3`/`6.0.3` on each regeneration.
- **e2e** (Cucumber) fails with `Cannot find module 'ts-node/register'` — `ts-node` only survived in the lockfile as an *accidental optional peer* of `jest-config`.

Rebasing via `@dependabot rebase` does **not** fix it (regeneration reproduces the bug).

## Fix (no change to what the app builds against)

- Add **`ts-node`** as an explicit `devDependency` — it is genuinely used by the e2e suite (`ts-node/register`). Making it explicit also strips the `optional/peer` flags off its whole subtree, so it's firmly required and can't be pruned.
- Pin the **`@lingui/conf` nested typescript** via `overrides` so it stops churning. Root `typescript` stays `4.6.4` (unchanged); `@lingui/conf`'s config is plain JS so it never actually loads typescript.

Net lockfile change is small and removes only `optional/peer` flags — no packages added/removed beyond the firm ts-node subtree.

## Why this is safe

- ts-node's peers are already satisfied (`typescript >=2.7`, `@types/node` present).
- The override is targeted to `@lingui/conf` only and pins to the version already in use (`5.9.3`); root typescript is untouched.
- Fully reversible (2 small edits in `package.json`).

## Validation

This PR's own CI proves build + e2e. After merge, the real test is to rebase **one** Dependabot PR and confirm it goes fully green before clearing the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)