### PR TITLE
Surface feature-acceptance policy to contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💡 Request or vote on a feature
+    url: https://feedback.fider.io
+    about: Feature ideas start here. Post or vote on a suggestion so the community can discuss it. New features need an accepted suggestion before we'll review a PR.
+  - name: 📋 Feature policy & roadmap discussion
+    url: https://github.com/getfider/fider/discussions/1529
+    about: How we decide which features get built, and why unsolicited feature PRs may be closed. Please read before proposing a new feature.
+  - name: 💬 Questions & help
+    url: https://github.com/getfider/fider/discussions
+    about: Have a question or need help? Ask in GitHub Discussions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,13 @@
-**Issue:** <!-- What's this PR for? Link it to a GitHub issue or create one before you submit this Pull Request. -->
+**Issue:** <!-- Link this PR to a GitHub issue. For anything beyond a small fix, open an issue first so we can agree on the approach. -->
 
 <!-- Briefly explain what is being changed with this Pull Request. -->
+
+---
+
+> **Before you submit:** PRs for new features that haven't been discussed and accepted may be closed. This isn't anti-AI — it's about reviewer burden and long-term maintainability. Please open an issue first. See [discussion #1529](https://github.com/getfider/fider/discussions/1529).
+
+**Checklist**
+
+- [ ] This PR is linked to a GitHub issue (bug fix or an agreed change).
+- [ ] **New feature only:** it relates to a suggestion on https://feedback.fider.io **and** a maintainer has confirmed on the linked issue that it's accepted onto the roadmap.
+- [ ] I've read the [Contributing guide](../CONTRIBUTING.md) and the feature policy in [discussion #1529](https://github.com/getfider/fider/discussions/1529).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,15 @@ There are many ways you can contribute to Fider.
 - **Spread the word** by starring us on GitHub. Tweet about the project and show it to your friends. The more people know about Fider, the bigger the community will be and more contributions will be made;
 - **Support us financially** by donating any amount to our [OpenCollective](https://opencollective.com/fider) and help us continue our activities;
 
+## Before you build a new feature
+
+We love contributions, but please help us keep them reviewable and maintainable. Before writing code for a **new feature**:
+
+- Features start as a suggestion on https://feedback.fider.io, where the community can discuss and vote on them. This helps us gauge whether a change is valuable to other users.
+- Once a suggestion has enough discussion and support, open a [GitHub Issue](https://github.com/getfider/fider/issues) referencing it and **wait for a maintainer to confirm it's accepted onto the roadmap** before you start building.
+- **Bug fixes and small technical improvements** don't need a feedback suggestion — an issue is still appreciated so we know what you're working on.
+- Pull Requests for features that weren't discussed and accepted may be closed. This isn't anti-AI — it's about reviewer burden and the long-term maintainability of Fider. See [discussion #1529](https://github.com/getfider/fider/discussions/1529) for the full reasoning.
+
 ## Getting started with Fider codebase
 
 Before start working on something that you intend to send a Pull Request, make sure there's an [GitHub Issue](https://github.com/getfider/fider/issues) open for that or create one yourself. If it's a new feature you're working on, please share your high level thoughts on the ticket so we can agree on a solution that aligns with the overall architecture and future of Fider.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://feedback.fider.io">Fider Feedback</a> •
     <a href="https://demo.fider.io">Fider Demo</a> •
     <a href="https://docs.fider.io">Docs</a> •
-    <a href="https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md">Contributing</a>
+    <a href="https://github.com/getfider/fider/blob/main/CONTRIBUTING.md">Contributing</a>
 </p>
 
 <br/>


### PR DESCRIPTION
Make the "new features need a discussed and accepted feedback.fider.io suggestion" policy from discussion #1529 visible at the moments people open issues and PRs, to reduce unsolicited feature PRs and reviewer load.

- PR template: add a neutral pre-submission note + checklist
- CONTRIBUTING.md: add "Before you build a new feature" section
- ISSUE_TEMPLATE/config.yml: disable blank issues, add contact links routing to the feedback board, the policy discussion, and Discussions
- README: fix Contributing link (pointed at TryGhost/Ghost)

