### PR TITLE
ci: skip publish job for fork PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,13 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Skip fork PRs: checkout refuses fork code in a trusted workflow_run context (pwn-request
+    # guard), and this job holds Docker Hub secrets. Fork PR images can be published on demand via
+    # publish-pr-multiarch.yml after review.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          (github.event.workflow_run.event != 'pull_request' ||
+           github.event.workflow_run.head_repository.full_name == github.repository) }}
     steps:
       - name: Dump GitHub context
         run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,9 @@ jobs:
           platforms: linux/amd64
           tags: getfider/fider:PR_${{ github.event.workflow_run.pull_requests[0].number }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # PR-triggered workflow_run gets a read-only cache token, so cache writes are
+          # denied; ignore-error keeps that from failing the build (reads still work).
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: build and push docker image (push branch)
         if: ${{ github.event.workflow_run.event == 'push' }}


### PR DESCRIPTION
Fixes two independent breakages in the `publish` workflow, both stemming from recent GitHub Actions security hardening.

## 1. Fork PRs — checkout refusal

Recent `publish` runs on fork PRs fail with:

> Refusing to check out fork pull request code from a 'workflow_run' workflow… set 'allow-unsafe-pr-checkout: true'.

New `actions/checkout` guard (GA v7 2026-06-18, backported to supported majors incl. v6 on 2026-07-16): it refuses to check out **fork** PR code inside a trusted `workflow_run` context. Our `publish` job runs there with Docker Hub creds and then builds the checked-out Dockerfile — a "pwn request" that could exfiltrate secrets. Rather than opt into `allow-unsafe-pr-checkout: true` (which re-opens that hole), skip fork PRs:

```yaml
if: >-
  ${{ github.event.workflow_run.conclusion == 'success' &&
      (github.event.workflow_run.event != 'pull_request' ||
       github.event.workflow_run.head_repository.full_name == github.repository) }}
```

Fork PRs → job skipped. Same-repo PRs, pushes, releases → unchanged. Fork PR images can still be published on demand via `publish-pr-multiarch.yml`.

## 2. Same-repo PRs — gha cache write denied

Around 2026-07-01, GitHub reduced the Actions cache token to **read-only** for `workflow_run` runs triggered by a `pull_request` (previously read/write). `cache-to: type=gha,mode=max` now returns `cache write denied: token has no writable scopes`, which buildx treats as **fatal**, failing the PR publish. Evidence: token scope went `read/write` (Jun 26 PR publish ✅) → `read` (Jul 1 PR publish ❌); push/release publishes still get `read/write` and pass.

Fix — make the denied write non-fatal on the `pull_request` step (reads via `cache-from` still work):

```yaml
cache-to: type=gha,mode=max,ignore-error=true
```

## Notes

- Rebased onto latest `main` (now on `actions/*@v7`); diff is limited to the two changes above.
- Rejected alternative for #1: `allow-unsafe-pr-checkout: true` — reintroduces the credential-exfiltration risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)