### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Install Fider on your own servers, in your own infrastructure. It's totally free
 
 If you do self-host and enjoy Fider, please [let us know where you're using it](https://github.com/getfider/fider/issues/899) - we really appreciate it 🙏
 
+## ⚡ **One-Click Managed (third-party)**
+
+Want a managed Fider without running a server yourself? Zenith Hosting deploys Fider for you with storage, backups, email and a free subdomain included, and shares a cut of every subscription back with Fider.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/fider)
+
 # 💰 Donations and Sponsors
 
 Support the development of Fider to help us make it the best feedback tool! You can set up donations as small or large as you want to help us keep Fider going. [Donate](https://opencollective.com/fider)


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Fider to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Getting Started (a neutral third-party managed option after Self-Hosted, links to https://zenith.hosting/host/fider).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

this is docs-only (one line + badge in the README), additions-only, no code touched.

---

**Issue:** none — docs-only addition, no linked issue. happy to open one first if you'd prefer; flagging that your PR template asks for it.

Adds a "Deploy with Zenith" badge as a third-party one-click managed hosting option under Getting Started, placed after Self-Hosted (not next to Fider Cloud).

---

> **Before you submit:** PRs for new features that haven't been discussed and accepted may be closed. This isn't anti-AI — it's about reviewer burden and long-term maintainability. Please open an issue first. See [discussion #1529](https://github.com/getfider/fider/discussions/1529).

**Checklist**

- [ ] This PR is linked to a GitHub issue (bug fix or an agreed change). <!-- docs-only, no issue yet — glad to open one -->
- [ ] **New feature only:** it relates to a suggestion on https://feedback.fider.io **and** a maintainer has confirmed on the linked issue that it's accepted onto the roadmap. <!-- N/A, not a feature (docs only) -->
- [x] I've read the [Contributing guide](../CONTRIBUTING.md) and the feature policy in [discussion #1529](https://github.com/getfider/fider/discussions/1529).
