### PR TITLE
Stop retrying Let's Encrypt for hosts that just failed

### DIFF
--- a/app/pkg/web/ssl.go
+++ b/app/pkg/web/ssl.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"golang.org/x/crypto/acme"
 	"golang.org/x/net/idna"
@@ -42,6 +44,60 @@ func getDefaultTLSConfig(autoSSL bool) *tls.Config {
 }
 
 var errInvalidHostName = errors.New("autotls: invalid hostname")
+
+// certFailureCooldown is how long a host is skipped after a failed certificate acquisition.
+// Let's Encrypt allows roughly 5 failed validations per hostname per hour, so this keeps us
+// to at most 4, leaving headroom for the rest of the account.
+const certFailureCooldown = 15 * time.Minute
+
+// hostFailureCache records hosts whose certificate acquisition recently failed, so that we
+// stop asking Let's Encrypt for them until the cooldown elapses. Without it a single broken
+// custom domain retries on every TLS handshake, which rate limits the whole ACME account.
+type hostFailureCache struct {
+	mu       sync.Mutex
+	failures map[string]time.Time
+}
+
+func newHostFailureCache() *hostFailureCache {
+	return &hostFailureCache{failures: make(map[string]time.Time)}
+}
+
+// normalizeHost matches how autocert canonicalizes the name it hands to the HostPolicy, so
+// that failures recorded from a raw ServerName are found again on the next handshake.
+func normalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(host), ".")
+}
+
+func (c *hostFailureCache) onCooldown(host string) bool {
+	key := normalizeHost(host)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	failedAt, ok := c.failures[key]
+	if !ok {
+		return false
+	}
+
+	if time.Since(failedAt) >= certFailureCooldown {
+		delete(c.failures, key)
+		return false
+	}
+
+	return true
+}
+
+func (c *hostFailureCache) recordFailure(host string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failures[normalizeHost(host)] = time.Now()
+}
+
+func (c *hostFailureCache) clear(host string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.failures, normalizeHost(host))
+}
 
 func isValidHostName(ctx context.Context, host string) error {
 	// In this context, host can only be custom domains, not a subdomain of fider.io
@@ -88,23 +144,25 @@ func isValidHostName(ctx context.Context, host string) error {
 
 // CertificateManager is used to manage SSL certificates
 type CertificateManager struct {
-	ctx     context.Context
-	cert    tls.Certificate
-	leaf    *x509.Certificate
-	autotls autocert.Manager
+	ctx      context.Context
+	cert     tls.Certificate
+	leaf     *x509.Certificate
+	autotls  autocert.Manager
+	failures *hostFailureCache
 }
 
 // NewCertificateManager creates a new CertificateManager
 func NewCertificateManager(ctx context.Context, certFile, keyFile string) (*CertificateManager, error) {
 	manager := &CertificateManager{
-		ctx: ctx,
+		ctx:      ctx,
+		failures: newHostFailureCache(),
 		autotls: autocert.Manager{
-			Prompt:     autocert.AcceptTOS,
-			Cache:      NewAutoCertCache(),
-			Client:     acmeClient(),
-			HostPolicy: isValidHostName,
+			Prompt: autocert.AcceptTOS,
+			Cache:  NewAutoCertCache(),
+			Client: acmeClient(),
 		},
 	}
+	manager.autotls.HostPolicy = manager.hostPolicy
 
 	if certFile != "" && keyFile != "" {
 		var err error
@@ -120,6 +178,16 @@ func NewCertificateManager(ctx context.Context, certFile, keyFile string) (*Cert
 	}
 
 	return manager, nil
+}
+
+// hostPolicy is the autocert HostPolicy. autocert calls it before looking up or issuing a
+// certificate, but after serving TLS-ALPN challenge tokens, so refusing a host here stops us
+// from contacting Let's Encrypt without interfering with an in-flight challenge validation.
+func (m *CertificateManager) hostPolicy(ctx context.Context, host string) error {
+	if m.failures.onCooldown(host) {
+		return errors.Wrap(errInvalidHostName, "host %s is on cooldown after a recent certificate failure", host)
+	}
+	return isValidHostName(ctx, host)
 }
 
 // GetCertificate decides which certificate to use
@@ -167,8 +235,21 @@ func (m *CertificateManager) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Ce
 				log.Debug(m.ctx, err.Error())
 			}
 		} else {
-			log.Error(m.ctx, errors.Wrap(err, "failed to get certificate for %s", hello.ServerName))
+			// Put the host on cooldown so a domain that can't be issued doesn't retry on every
+			// handshake and get the ACME account rate limited.
+			m.failures.recordFailure(hello.ServerName)
+
+			failure := errors.Wrap(err, "failed to get certificate for %s", hello.ServerName)
+			// Same rationale as above: in multi-tenant mode a custom domain that fails ACME is
+			// the customer's problem to fix, not a Fider bug, so keep it out of error alarms.
+			if env.IsSingleHostMode() {
+				log.Error(m.ctx, failure)
+			} else {
+				log.Warn(m.ctx, failure.Error())
+			}
 		}
+	} else {
+		m.failures.clear(hello.ServerName)
 	}
 
 	return cert, err

--- a/app/pkg/web/ssl_test.go
+++ b/app/pkg/web/ssl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getfider/fider/app/models/query"
 	"github.com/getfider/fider/app/pkg/bus"
 	"github.com/getfider/fider/app/pkg/env"
+	"github.com/getfider/fider/app/pkg/errors"
 	"github.com/getfider/fider/app/services/blob/fs"
 
 	. "github.com/getfider/fider/app/pkg/assert"
@@ -150,6 +151,53 @@ func TestGetCertificate_ServerNameMatchesCertificate_ShouldReturnIt(t *testing.T
 		Expect(err).IsNil()
 		Expect(cert).IsNotNil()
 	}
+}
+
+func TestHostPolicy_WhenHostRecentlyFailed_ShouldSkipWithoutHittingLetsEncrypt(t *testing.T) {
+	RegisterT(t)
+	bus.Init(fs.Service{})
+	bus.AddHandler(mockGetTenantWithCorrectSubdomains)
+
+	manager, err := NewCertificateManager(context.Background(), "", "")
+	Expect(err).IsNil()
+
+	// a host with no recorded failure is handed over to isValidHostName, which rejects it
+	// because no tenant is registered with that cname
+	err = manager.hostPolicy(context.Background(), "feedback.heyworld.com")
+	Expect(errors.Cause(err)).Equals(errInvalidHostName)
+	Expect(err.Error()).ContainsSubstring("no tenant found with cname feedback.heyworld.com")
+
+	// once it fails, the host is skipped for the cooldown period
+	manager.failures.recordFailure("feedback.heyworld.com")
+	err = manager.hostPolicy(context.Background(), "feedback.heyworld.com")
+	Expect(errors.Cause(err)).Equals(errInvalidHostName)
+	Expect(err.Error()).ContainsSubstring("is on cooldown after a recent certificate failure")
+
+	// a successful handshake clears the cooldown
+	manager.failures.clear("feedback.heyworld.com")
+	err = manager.hostPolicy(context.Background(), "feedback.heyworld.com")
+	Expect(err.Error()).ContainsSubstring("no tenant found with cname feedback.heyworld.com")
+}
+
+func TestHostFailureCache(t *testing.T) {
+	RegisterT(t)
+
+	cache := newHostFailureCache()
+	Expect(cache.onCooldown("feedback.heyworld.com")).IsFalse()
+
+	cache.recordFailure("feedback.heyworld.com")
+	Expect(cache.onCooldown("feedback.heyworld.com")).IsTrue()
+	// autocert lowercases and strips the trailing dot before calling the host policy, so a
+	// failure recorded from a raw ServerName must still be found
+	Expect(cache.onCooldown("FEEDBACK.HeyWorld.com.")).IsTrue()
+	Expect(cache.onCooldown("ideas.app.com")).IsFalse()
+
+	cache.clear("feedback.heyworld.com")
+	Expect(cache.onCooldown("feedback.heyworld.com")).IsFalse()
+
+	// a failure older than the cooldown lets the host through again
+	cache.failures[normalizeHost("feedback.heyworld.com")] = time.Now().Add(-certFailureCooldown - time.Second)
+	Expect(cache.onCooldown("feedback.heyworld.com")).IsFalse()
 }
 
 func TestGetCertificate_ServerNameDoesntMatchCertificate_ButEndsWithHostName_ShouldThrow(t *testing.T) {


### PR DESCRIPTION
## Problem

A single tenant custom domain has generated ~1,636 production `ERROR` log lines in 7 days — **74% of all production errors** — and has now got our Let's Encrypt account **rate limited (429)**, which puts certificate issuance at risk for other legitimate tenants.

Three variants show up in the logs, all from `ssl.go:170`:

- `acme/autocert: missing certificate` (~1,222)
- `429 urn:ietf:params:acme:error:rateLimited` (~400)
- `context deadline exceeded` (9)

## Root cause

The obvious reading is "the customer's DNS is broken", but that isn't what's happening. A broken CNAME fails `isValidHostName` and is logged at `Debug`. These errors are on the *other* branch of that `if`, so **the CNAME check is passing** — the domain resolves correctly and issuance itself is what fails.

The loop is driven by autocert internals:

1. Issuance fails, and autocert leaves behind an empty in-memory `certState` that is only cleared after `createCertRetryAfter` (**1 minute**).
2. Every handshake inside that window short-circuits on the empty state → `acme/autocert: missing certificate` (variant A).
3. The state clears, the next handshake goes straight back to Let's Encrypt → eventually `429` (variant B).
4. Repeat forever.

There was no cooldown anywhere in the path, so nothing broke the cycle.

## Fix

Record hosts whose certificate acquisition fails and skip them for a 15 minute cooldown.

The gate lives in the autocert `HostPolicy`, which is deliberate: autocert calls it **before** looking up or issuing a certificate, but **after** serving TLS-ALPN challenge tokens. So a host on cooldown never reaches Let's Encrypt, while an in-flight challenge validation is left untouched. A cooldown rejection wraps `errInvalidHostName`, so it flows through the existing quiet-logging branch.

15 minutes keeps us to ≤4 attempts/hour/host, under Let's Encrypt's ~5 failed-validations-per-hostname-per-hour limit, with headroom for the rest of the account. It's a single const if we want to tune it.

Also downgrades these failures to `WARN` in multi-tenant mode. A custom domain that fails ACME is a customer DNS/setup problem rather than a Fider bug, and at `ERROR` it drowns out genuine errors and trips the CloudWatch alarm. Single-host mode keeps `ERROR`, where the domain belongs to the operator.

## Verification

- Temporary test driving 25 handshakes against a permanently-failing host: reached Let's Encrypt **once instead of 25 times**. Removed before commit.
- New unit tests cover the cooldown gate, key normalization (autocert lowercases/strips the trailing dot before calling the policy), expiry, and clear-on-success.
- `make lint` clean; `app/pkg/web` passes. Two unrelated failures (`TestGravatarHandler`, `TestGetMainEngine`) reproduce on a clean `main` and are not from this change.

## Note — this does not un-pause the account

Ops still needs to clear the offending `cname` (or get the customer to fix their DNS) and hit the Let's Encrypt unpause link. This change caps the damage going forward; it can't lift the current pause.

## Possible follow-up

Custom domains are a free-text `cname` column with no verification state, so a bad domain reaches ACME at all only because nothing checks it at save time. Persisting a verified flag and checking the CNAME when it's configured would stop this class at the source — happy to raise separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)