### PR TITLE
build(deps): bump typescript to 4.9.5 to stop dependabot lockfile breakage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "svg-sprite-loader": "6.0.11",
         "svgo-loader": "3.0.0",
         "ts-node": "^10.9.2",
-        "typescript": "4.6.4",
+        "typescript": "4.9.5",
         "webpack": "5.108.4",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.9.2"
@@ -4209,21 +4209,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@lingui/conf/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@lingui/core": {
@@ -19645,10 +19630,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "dev": true,
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -73,15 +73,10 @@
     "svg-sprite-loader": "6.0.11",
     "svgo-loader": "3.0.0",
     "ts-node": "^10.9.2",
-    "typescript": "4.6.4",
+    "typescript": "4.9.5",
     "webpack": "5.108.4",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.2"
-  },
-  "overrides": {
-    "@lingui/conf": {
-      "typescript": "5.9.3"
-    }
   },
   "browserslist": ">1%, not dead",
   "jest": {

--- a/public/services/http.ts
+++ b/public/services/http.ts
@@ -52,7 +52,7 @@ async function toResult<T>(response: Response): Promise<Result<T>> {
   }
 }
 async function request<T>(url: string, method: "GET" | "POST" | "PUT" | "DELETE", body?: any): Promise<Result<T>> {
-  const headers = [
+  const headers: [string, string][] = [
     ["Accept", "application/json"],
     ["Content-Type", "application/json"],
   ]


### PR DESCRIPTION
## Why

Every npm Dependabot PR has been failing CI at `npm ci` with:

```
npm error Missing: typescript@5.9.3 from lock file
```

## Root cause

`cosmiconfig@8` (pulled in by `@lingui/conf`) declares `typescript` as an **optional peer** with range `>=4.9.5`. Root `typescript` was pinned at `4.6.4`, which does **not** satisfy that range — so npm resolved a *separate* nested copy into `main`'s lockfile:

```
node_modules/@lingui/conf/node_modules/typescript  (5.9.3, optional: true, peer: true)
```

Dependabot's lockfile regeneration **prunes optional peers**, so every Dependabot PR dropped that node and `npm ci` then rejected the lockfile as out of sync. The per-PR lockfile surgery this required was not sustainable, and the `overrides.@lingui/conf.typescript` hack from #1583 never actually fixed it (it only pinned the *version* of the nested copy, not its optionality).

## Fix

Bump root `typescript` `4.6.4` → `4.9.5` — the **smallest** version that satisfies cosmiconfig's peer range. The nested copy now dedupes into the single firm **direct** dependency, so there is nothing optional left for Dependabot to prune. This is deterministic (a satisfied optional peer dedupes to root), not npm-version-dependent luck. The obsolete `overrides` block is removed.

TS 4.9's stricter `lib.dom.d.ts` required one type annotation in `http.ts` (`HeadersInit` wants `[string, string][]`, not `string[][]`).

## Validation

- `npm ci`, `make lint-ui`, `make build-ui`, `make test-ui` — all pass locally.
- Simulated a Dependabot regen on top of this change: no nested `typescript` reappears, `npm ci` stays clean.

## Follow-up

Once merged, the three currently-broken Dependabot PRs (#1622, #1621, #1620) just need `@dependabot rebase` — they'll regenerate cleanly against this `main` and go green on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)