### PR TITLE
build(deps-dev): bump purgecss-webpack-plugin 4.1.3 -> 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "jest-environment-jsdom": "28.1.0",
         "mini-css-extract-plugin": "2.10.2",
         "prettier": "2.6.2",
-        "purgecss-webpack-plugin": "4.1.3",
+        "purgecss-webpack-plugin": "8.0.0",
         "sass": "1.102.0",
         "sass-loader": "12.6.0",
         "svg-sprite-loader": "6.0.11",
@@ -16708,44 +16708,57 @@
       }
     },
     "node_modules/purgecss": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.1.3.tgz",
-      "integrity": "sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-8.0.0.tgz",
+      "integrity": "sha512-QFJyps9y5oHeXnNA3Ql1EaAqWBivNwQn19Pw1lt9RxfB+4e+bIyqCyuombk79D6Fxe+lPXggVfI1WtRGEBwgbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^8.0.0",
-        "glob": "^7.1.7",
-        "postcss": "^8.3.5",
-        "postcss-selector-parser": "^6.0.6"
+        "commander": "^12.1.0",
+        "fast-glob": "^3.3.2",
+        "postcss": "^8.4.47",
+        "postcss-selector-parser": "^7.0.0"
       },
       "bin": {
         "purgecss": "bin/purgecss.js"
       }
     },
     "node_modules/purgecss-webpack-plugin": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/purgecss-webpack-plugin/-/purgecss-webpack-plugin-4.1.3.tgz",
-      "integrity": "sha512-1OHS0WE935w66FjaFSlV06ycmn3/A8a6Q+iVUmmCYAujQ1HPdX+psMXUhASEW0uF1PYEpOlhMc5ApigVqYK08g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/purgecss-webpack-plugin/-/purgecss-webpack-plugin-8.0.0.tgz",
+      "integrity": "sha512-BwPFsmDJJygZQSsyxm4GOOs2Etggk0I4XqMZBAN8ssxzSdeaEbFap6jrhzq4nq/ONX7B5/D5gwq6AUeTvyujdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "purgecss": "^4.1.3",
-        "webpack": "^5.4.0",
-        "webpack-sources": "^3.2.0"
+        "purgecss": "^8.0.0",
+        "webpack": ">=5.95.0"
       },
       "peerDependencies": {
-        "webpack": "*"
+        "webpack": ">=5.0.0"
       }
     },
     "node_modules/purgecss/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/purgecss/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/query-string": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jest-environment-jsdom": "28.1.0",
     "mini-css-extract-plugin": "2.10.2",
     "prettier": "2.6.2",
-    "purgecss-webpack-plugin": "4.1.3",
+    "purgecss-webpack-plugin": "8.0.0",
     "sass": "1.102.0",
     "sass-loader": "12.6.0",
     "svg-sprite-loader": "6.0.11",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const path = require("path")
 const glob = require("glob")
 
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
-const PurgecssPlugin = require("purgecss-webpack-plugin")
+const { PurgeCSSPlugin } = require("purgecss-webpack-plugin")
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin
 const publicFolder = path.resolve(__dirname, "public")
@@ -35,7 +35,7 @@ const plugins = [
 
 if (isProduction) {
   plugins.push(
-    new PurgecssPlugin({
+    new PurgeCSSPlugin({
       paths: [...glob.sync(`./public/**/*.{html,tsx}`, { nodir: true })],
       defaultExtractor: (content) => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
       safelist: [/--/, /__/, /data-/, /tiptap/],


### PR DESCRIPTION
Supersedes #1595.

## Why #1595 failed

The docker build failed with:

```
[webpack-cli] TypeError: PurgecssPlugin is not a constructor
```

`purgecss-webpack-plugin` v5+ changed from a **default export** to a **named export**, and renamed the class to `PurgeCSSPlugin`. The v4 import style (`const PurgecssPlugin = require(...)`) yields an object in v8, so `new PurgecssPlugin(...)` throws.

## Fix

`webpack.config.js`:
```js
- const PurgecssPlugin = require("purgecss-webpack-plugin")
+ const { PurgeCSSPlugin } = require("purgecss-webpack-plugin")
...
-     new PurgecssPlugin({
+     new PurgeCSSPlugin({
```

The plugin options (`paths`, `defaultExtractor`, `safelist`) are unchanged and still valid in v8.

## Validation

- Production `make build-ui` (`NODE_ENV=production`) — PurgeCSS runs, CSS is emitted and correctly purged (output sizes healthy, safelist honoured).
- `make lint-ui`, `make test-ui` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)