### PR TITLE
build(deps): hold entangled major toolchain bumps (jest 30, babel 8, marked 18)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,29 @@ updates:
       #   upgrade first. Held on the 5.1 line.
       - dependency-name: "@lingui/*"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      # Test/build toolchain majors — jest 30 and @babel/core 8 each require a
+      #   COORDINATED migration of the whole entangled stack (jest + jest-environment-jsdom
+      #   + babel-jest + @babel/* presets + jsdom), not a single bump. Bumping one alone
+      #   fails: jest 30 -> `clearMocksOnScope is not a function`; @babel/core 8 -> ERESOLVE
+      #   vs @babel/cli@7 / babel-jest@28. Held on the current majors until done as a
+      #   dedicated task; minor/patch within them still flow.
+      - dependency-name: "jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jest-environment-jsdom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "babel-jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "babel-loader"
+        update-types: ["version-update:semver-major"]
+      # marked: 5+ is ESM-only and rewrote the Renderer API. 4 -> 18 needs a rewrite of
+      #   public/services/markdown.ts (custom marked.Renderer() + synchronous marked()).
+      #   Held on the 4.x line until that migration is done.
+      - dependency-name: "marked"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/marked"
+        update-types: ["version-update:semver-major"]
 
   # Go modules - monthly, all grouped together
   - package-ecosystem: "gomod"


### PR DESCRIPTION
Three new Dependabot PRs failed together (#1630, #1634, #1631). Unlike the previous batches, **none is a quick win** — each is a major migration entangled with others.

## Why each can't just be bumped

| PR | Bump | Failure | Why it's a migration, not a bump |
|----|------|---------|----------------------------------|
| #1630 | `jest` 28 → 30 | `test-ui`: `this._moduleMocker.clearMocksOnScope is not a function` | jest core moved ahead of `jest-environment-jsdom` / `babel-jest` (still 28). Needs the whole jest stack + jsdom moved together, with test-behavior changes. |
| #1634 | `@babel/core` 7 → 8 | `npm ci` `ERESOLVE` | `@babel/cli@7` and `babel-jest@28` peer-require `@babel/core@^7`. Babel 8 needs `@babel/cli`, presets, `babel-jest`, `babel-loader` all on 8 — and that's tied to the jest bump above. |
| #1631 | `marked` 4 → 18 | `test-ui`: marked ESM loader throws | marked 5+ is **ESM-only** and rewrote the `Renderer` API. `public/services/markdown.ts` uses `new marked.Renderer()` + synchronous `marked(...)` — needs a rewrite. |

## What this PR does

Adds **semver-major** `ignore` rules for the jest stack (`jest`, `jest-environment-jsdom`, `babel-jest`), the babel toolchain (`@babel/*`, `babel-loader`), and `marked` / `@types/marked` — so these stop generating failing PRs every cycle. **Minor/patch within the current majors still flow.** Each stays unblockable by doing it as a dedicated, coordinated migration later.

This is the same land-safe / hold-blocked pattern used for playwright, tiptap-markdown, @lingui/*, and aws-sdk-go.

## Follow-up

Close #1630, #1634, #1631 once this merges. (#1434 node 22→25 should also be closed — Node 25 is non-LTS; target Node 24 if/when a base bump is wanted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)