### PR TITLE
build(deps): move Docker base image and CI to Node 24 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
       - run: npm ci
       - run: make lint-ui
@@ -61,7 +61,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
       - run: npm ci # required for esbuild
       - name: install golangci-lint
@@ -134,7 +134,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
       - uses: actions/download-artifact@v8
         with:
@@ -189,7 +189,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
       - uses: actions/download-artifact@v8
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 #################
 ### UI Build Step
 #################
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:22-bookworm AS ui-builder 
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:24-bookworm AS ui-builder 
 
 WORKDIR /ui
 


### PR DESCRIPTION
Supersedes #1434 (which proposed Node **25** — non-LTS/odd-numbered, ~6-month support window).

Moves to **Node 24**, the current LTS:
- `Dockerfile:30` `node:22-bookworm` → `node:24-bookworm` (the only node stage).
- `.github/workflows/build.yml` — all four `node-version: 22.x` → `24.x`, keeping CI and the built image aligned.

Verified by CI (build + tests run on Node 24). Close #1434 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)