### PR TITLE
build(deps): rewrite markdown renderer for marked 4 → 17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,12 +47,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "babel-loader"
         update-types: ["version-update:semver-major"]
-      # marked: 5+ is ESM-only and rewrote the Renderer API. 4 -> 18 needs a rewrite of
-      #   public/services/markdown.ts (custom marked.Renderer() + synchronous marked()).
-      #   Held on the 4.x line until that migration is done.
+      # marked: now on 17 (renderer rewritten to the token-based API in markdown.ts).
+      #   Held on 17.x because @tiptap/markdown peers marked ^17; unblock 18 once the
+      #   editor's @tiptap/markdown supports it.
       - dependency-name: "marked"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/marked"
         update-types: ["version-update:semver-major"]
 
   # Go modules - monthly, all grouped together

--- a/babel.config.json
+++ b/babel.config.json
@@ -2,11 +2,7 @@
   "presets": ["@babel/env", "@babel/react", "@babel/preset-typescript"],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
-    ["macros", {
-      "lingui": {
-        "version": 5
-      }
-    }],
+    ["macros", { "lingui": { "version": 5 } }],
     "@lingui/babel-plugin-lingui-macro"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@tiptap/suggestion": "^2.11.5",
         "dompurify": "^3.4.12",
         "inter-ui": "^4.1.1",
-        "marked": "^4.0.15",
+        "marked": "^17.0.6",
         "prosemirror-markdown": "^1.13.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -46,7 +46,6 @@
         "@types/debug": "4.1.13",
         "@types/dompurify": "3.2.0",
         "@types/jsdom": "16.2.14",
-        "@types/marked": "4.0.3",
         "@types/node": "17.0.31",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -5770,13 +5769,6 @@
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
       }
-    },
-    "node_modules/@types/marked": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.3.tgz",
-      "integrity": "sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
@@ -14697,15 +14689,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tiptap/suggestion": "^2.11.5",
     "dompurify": "^3.4.12",
     "inter-ui": "^4.1.1",
-    "marked": "^4.0.15",
+    "marked": "^17.0.6",
     "prosemirror-markdown": "^1.13.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -42,7 +42,6 @@
     "@types/debug": "4.1.13",
     "@types/dompurify": "3.2.0",
     "@types/jsdom": "16.2.14",
-    "@types/marked": "4.0.3",
     "@types/node": "17.0.31",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -82,7 +81,7 @@
   "jest": {
     "testEnvironment": "jsdom",
     "transform": {
-      ".+\\.(tsx|ts)?$": "babel-jest"
+      ".+\\.(t|j)sx?$": "babel-jest"
     },
     "setupFilesAfterEnv": [
       "<rootDir>/public/jest.setup.tsx"
@@ -100,7 +99,10 @@
       ".*\\.(png|scss|svg)$": "<rootDir>/public/jest.assets.ts",
       "@fider/(.*)": "<rootDir>/public/$1",
       "@locale/(.*)": "<rootDir>/locale/$1"
-    }
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(marked)/)"
+    ]
   },
   "engines": {
     "npm": "10.x || 11.x",

--- a/public/services/markdown.ts
+++ b/public/services/markdown.ts
@@ -1,14 +1,6 @@
-import { marked } from "marked"
+import { Marked, RendererObject } from "marked"
 import DOMPurify from "dompurify"
 import { fiderAllowedSchemes } from "@fider/hooks"
-
-marked.setOptions({
-  headerIds: false,
-  xhtml: true,
-  smartLists: true,
-  gfm: true,
-  breaks: true,
-})
 
 if (DOMPurify.isSupported) {
   DOMPurify.setConfig({
@@ -34,43 +26,85 @@ if (DOMPurify.isSupported) {
   })
 }
 
-const link = (href: string, title: string, text: string) => {
-  const titleAttr = title ? ` title=${title}` : ""
-  return `<a class="text-link" href="${href}"${titleAttr} rel="noopener nofollow" target="_blank">${text}</a>`
-}
+// marked 5+ escapes text (including ' -> &#39;). We keep apostrophes literal to match the
+// historical output, while preserving existing entities and escaping & < > ".
+const escapeText = (s: string): string =>
+  s
+    .replace(/&(?![#\w]+;)/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
 
-const fullRenderer = new marked.Renderer()
-const originalImage = fullRenderer.image.bind(fullRenderer)
-fullRenderer.image = (href, title, alt) => {
-  // Check if this is our special fider-image syntax
-  if (href && href.startsWith("fider-image:")) {
-    const bkey = href.substring("fider-image:".length)
-    return `<img src="/static/images/${bkey}" alt="${alt || ""}" class="fider-inline-image" data-bkey="${bkey}" />`
-  }
-  return originalImage(href, title, alt)
-}
-fullRenderer.link = link
-fullRenderer.text = (text: string) => {
-  // Handling mention links (they're in the format @[name])
-  return text.replace(/@\[(.*?)\]/g, (match, name) => {
-    return `<span class="mention">@${name}</span>`
-  })
-}
+// Expand Fider's proprietary mention syntax @[name] into a styled span.
+const renderMentions = (html: string): string => html.replace(/@\[(.*?)\]/g, (_match, name) => `<span class="mention">@${name}</span>`)
 
-const plainTextRenderer = new marked.Renderer()
-plainTextRenderer.link = (_href, _title, text) => text
-plainTextRenderer.image = () => ""
-plainTextRenderer.br = () => " "
-plainTextRenderer.strong = (text) => text
-plainTextRenderer.list = (body) => body
-plainTextRenderer.listitem = (text) => `${text} `
-plainTextRenderer.heading = (text) => text
-plainTextRenderer.paragraph = (text) => ` ${text} `
-plainTextRenderer.code = (code) => code
-plainTextRenderer.codespan = (code) => code
-plainTextRenderer.html = (html) => html
-plainTextRenderer.del = (text) => text
-plainTextRenderer.blockquote = (quote) => quote
+// marked 5+ replaced the positional Renderer API with token objects and requires renderer
+// overrides to be registered via .use(). Typing as RendererObject binds `this` to the
+// renderer (exposing this.parser) and infers the exact token types. Unoverridden methods
+// keep marked's defaults.
+const fullRenderer: RendererObject = {
+  image({ href, text }) {
+    // Fider's proprietary inline-image syntax: ![](fider-image:<bkey>)
+    if (href && href.startsWith("fider-image:")) {
+      const bkey = href.substring("fider-image:".length)
+      return `<img src="/static/images/${bkey}" alt="${text || ""}" class="fider-inline-image" data-bkey="${bkey}" />`
+    }
+    return false // fall back to marked's default image renderer
+  },
+  link({ href, title, tokens }) {
+    const text = this.parser.parseInline(tokens)
+    const titleAttr = title ? ` title=${title}` : ""
+    return `<a class="text-link" href="${href}"${titleAttr} rel="noopener nofollow" target="_blank">${text}</a>`
+  },
+  text(token) {
+    const rendered = "tokens" in token && token.tokens ? this.parser.parseInline(token.tokens) : escapeText(token.text)
+    return renderMentions(rendered)
+  },
+}
+const markedFull = new Marked({ gfm: true, breaks: true })
+markedFull.use({ renderer: fullRenderer })
+
+// Plain-text renderer: strip all formatting down to readable text.
+const plainTextRenderer: RendererObject = {
+  link({ tokens }) {
+    return this.parser.parseInline(tokens)
+  },
+  image() {
+    return ""
+  },
+  br() {
+    return " "
+  },
+  strong({ tokens }) {
+    return this.parser.parseInline(tokens)
+  },
+  del({ tokens }) {
+    return this.parser.parseInline(tokens)
+  },
+  heading({ tokens }) {
+    return this.parser.parseInline(tokens)
+  },
+  paragraph({ tokens }) {
+    return ` ${this.parser.parseInline(tokens)} `
+  },
+  code({ text }) {
+    return text
+  },
+  codespan({ text }) {
+    return text
+  },
+  html({ text }) {
+    return text
+  },
+  blockquote({ tokens }) {
+    return this.parser.parse(tokens)
+  },
+  list(token) {
+    return token.items.map((item) => `${this.parser.parse(item.tokens).trim()} `).join("")
+  },
+}
+const markedPlainText = new Marked({ gfm: true, breaks: true })
+markedPlainText.use({ renderer: plainTextRenderer })
 
 const encodeHTML = (s: string) => s.replace(/</g, "&lt;")
 const stripTags = (input: string) => input.replace(/<[^>]*>/g, "")
@@ -91,10 +125,10 @@ const decodeHtmlEntities = (text: string): string => {
 }
 
 export const full = (input: string): string => {
-  return sanitize(marked(encodeHTML(input), { renderer: fullRenderer }).trim())
+  return sanitize((markedFull.parse(encodeHTML(input)) as string).trim())
 }
 
 export const plainText = (input: string): string => {
-  const text = sanitize(marked(input, { renderer: plainTextRenderer }).trim())
+  const text = sanitize((markedPlainText.parse(input) as string).trim())
   return decodeHtmlEntities(text).trim()
 }


### PR DESCRIPTION
First step of unifying the app's **two** markdown engines onto marked (see the tiptap-v3 / markdown-consolidation plan). Upgrades the display **renderer** (`public/services/markdown.ts`) off the ancient marked 4 — held until now by a dependabot ignore — to **marked 17**, the version `@tiptap/markdown` peers, so the later editor migration dedupes to a single marked copy.

## Why it's a rewrite

marked 5+ is **ESM-only** and replaced the positional `Renderer` API with token objects registered via `.use()`. The `marked.Renderer()` + per-call `{renderer}` pattern no longer exists.

## Changes

- **`markdown.ts`**: two `Marked` instances (full + plain-text) with `RendererObject` overrides. Custom escape keeps apostrophes literal (marked now emits `&#39;`); the proprietary `![](fider-image:<bkey>)` and `@[mention]` syntaxes are preserved **byte-identically**.
- **`package.json`**: `marked` `^4.0.15` → `^17.0.6`; remove `@types/marked` (marked ships its own types); jest `transform` now includes `.js` and `transformIgnorePatterns` allows transforming marked's ESM.
- **`.babelrc` → `babel.config.json`**: jest needs a **root** babel config to transform ESM `node_modules` (a file-scoped `.babelrc` doesn't apply to them). Webpack's `babel-loader` only processes `public/` + `locale/`, so the production build is unaffected.
- **`dependabot.yml`**: `marked` now held on **17.x** (was 4.x), pending `@tiptap/markdown` supporting marked 18.

## Validation

- `markdown.spec.ts` — **32/32 byte-identical** (the renderer output contract, incl. links, images, mentions, XSS, hard-breaks, entity escaping).
- `make lint-ui`, `make build-ui`, `make test-ui` — all green.

## Follow-up

Clears the held marked-4 debt. Next in the plan: tiptap v2→v3, then the editor engine swap to `@tiptap/markdown` (dedupes onto this marked 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)